### PR TITLE
add-prod-unique-ids

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -71,3 +71,6 @@ jobs:
           aws_ec2_instance_root_vol_size: 16
 
           repo_env: repo_env
+
+          aws_resource_identifier: ${{ inputs.environment == 'prod' && 'bitovi-jira-mcp-auth-bridge-prod' || '' }} 
+          tf_state_bucket: ${{ inputs.environment == 'prod' && 'bitovi-jira-mcp-auth-bridge-prod-tf-state' || '' }}


### PR DESCRIPTION
In [v1.2.2](https://github.com/bitovi/cascade-mcp/blob/v1.2.2/.github/workflows/deploy-prod.yaml) the workflows and the name of the repo were different.
Once we migrated, a new deployment was done for staging, but prod was left untouched. 

In order to keep the old production deployment, the `aws_resource_identifier `and `tf_state_bucket` name must match the old ones. Defining those just for prod. 