### PR TITLE
Adds Google Drive OAuth configuration docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,15 @@ FIGMA_CLIENT_SECRET=YOUR_FIGMA_CLIENT_SECRET_HERE
 # Callback URL for Figma: {VITE_AUTH_SERVER_URL}/auth/callback/figma
 FIGMA_OAUTH_SCOPES="file_content:read file_metadata:read file_comments:read current_user:read"
 
+# --- Google Drive OAuth Configuration (OPTIONAL) ---
+# Google OAuth 2.0 client ID (from console.cloud.google.com)
+GOOGLE_CLIENT_ID=YOUR_GOOGLE_CLIENT_ID_HERE
+# Google OAuth 2.0 client secret (keep this secret!)
+GOOGLE_CLIENT_SECRET=YOUR_GOOGLE_CLIENT_SECRET_HERE
+# OAuth 2.0 scopes for Google Drive API access
+# Callback URL for Google: {VITE_AUTH_SERVER_URL}/auth/callback/google
+GOOGLE_OAUTH_SCOPES="https://www.googleapis.com/auth/drive"
+
 # --- OAuth Server Configuration ---
 # Base URL for this OAuth server (used in client registration/discovery)
 VITE_AUTH_SERVER_URL=http://localhost:3000

--- a/contributing.md
+++ b/contributing.md
@@ -204,7 +204,39 @@ You must register a new OAuth app in Figma to obtain credentials for MCP integra
    - `current_user:read`
 6. Save the app and copy the **Client ID** and **Client Secret**.
 
-### 3. Configure Environment Variables
+### 3. Create a Google OAuth App (Optional)
+
+If you want to use Google Drive integration, you'll need to create OAuth credentials in Google Cloud Console.
+
+**Steps:**
+1. Go to [Google Cloud Console](https://console.cloud.google.com/).
+2. Create a new project or select an existing one:
+   - Click the project dropdown in the top navigation bar
+   - Click **New Project**
+   - Enter a project name (e.g., `Cascade MCP Local`)
+   - Click **Create**
+3. Enable the Google Drive API:
+   - In the left sidebar, navigate to **APIs & Services** > **Library**
+   - Search for "Google Drive API"
+   - Click on **Google Drive API** in the results
+   - Click **Enable**
+4. Create OAuth 2.0 credentials:
+   - Navigate to **APIs & Services** > **Credentials**
+   - Click **Create Credentials** > **OAuth client ID**
+   - If prompted to configure OAuth consent screen:
+     - Select **External** user type
+     - Fill in required fields (App name, User support email, Developer contact)
+     - Add test users if needed for local development
+     - Save and continue through all steps
+   - Back on **Create OAuth client ID** screen:
+     - Select **Application type**: **Web application**
+     - **Name**: `Cascade MCP - Google Drive Local`
+     - Under **Authorized redirect URIs**, click **Add URI** and enter:
+       - `http://localhost:3000/auth/callback/google`
+     - Click **Create**
+5. Note your `Client ID` and `Client Secret` from the confirmation dialog
+
+### 4. Configure Environment Variables
 
 1. Copy the example environment file:
    ```bash
@@ -224,6 +256,11 @@ You must register a new OAuth app in Figma to obtain credentials for MCP integra
    - `FIGMA_CLIENT_SECRET` - Your Figma OAuth Client Secret
    - `FIGMA_OAUTH_SCOPES` - Should be `"file_content:read file_metadata:read file_comments:read current_user:read"`
 
+   **Google Drive OAuth** (from Step 3, optional):
+   - `GOOGLE_CLIENT_ID` - Your Google OAuth Client ID
+   - `GOOGLE_CLIENT_SECRET` - Your Google OAuth Client Secret
+   - `GOOGLE_OAUTH_SCOPES` - Should be `"https://www.googleapis.com/auth/drive"`
+
    **Note:** The `ANTHROPIC_API_KEY`, `SESSION_SECRET`, and `JWT_SECRET` variables were already set during API setup.
 
 3. **Understanding Callback URLs**: The application uses provider-specific callback URLs following the pattern:
@@ -232,6 +269,7 @@ You must register a new OAuth app in Figma to obtain credentials for MCP integra
    ```
    - Atlassian: `http://localhost:3000/auth/callback/atlassian`
    - Figma: `http://localhost:3000/auth/callback/figma`
+   - Google: `http://localhost:3000/auth/callback/google`
    
    These URLs **must match exactly** in your OAuth app configurations.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -38,6 +38,22 @@ Before deploying, you need to create OAuth applications for the services you wan
    - **Scopes**: `file_content:read file_comments:read current_user:read`
 4. Note your `Client ID` and `Client Secret`
 
+#### Google Drive OAuth App
+1. Go to [Google Cloud Console](https://console.cloud.google.com/)
+2. Create a new project or select an existing one
+3. Enable the Google Drive API:
+   - Navigate to **APIs & Services** > **Library**
+   - Search for "Google Drive API"
+   - Click **Enable**
+4. Create OAuth 2.0 credentials:
+   - Navigate to **APIs & Services** > **Credentials**
+   - Click **Create Credentials** > **OAuth client ID**
+   - Select **Application type**: **Web application**
+   - **Name**: Choose a descriptive name (e.g., "Cascade MCP Server")
+   - **Authorized redirect URIs**: Add `https://your-domain.com/auth/callback/google`
+   - Click **Create**
+5. Note your `Client ID` and `Client Secret` from the confirmation dialog
+
 ---
 
 ## Environment Configuration
@@ -69,6 +85,11 @@ VITE_JIRA_API_URL=https://api.atlassian.com/ex/jira
 FIGMA_CLIENT_ID=your-figma-client-id
 FIGMA_CLIENT_SECRET=your-figma-client-secret
 FIGMA_OAUTH_SCOPES="file_content:read file_comments:read current_user:read"
+
+# Google Drive OAuth
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_OAUTH_SCOPES="https://www.googleapis.com/auth/drive"
 
 # Optional: AWS (for CloudWatch logging)
 AWS_ACCESS_KEY_ID=your-aws-access-key


### PR DESCRIPTION
This pull request adds support for Google Drive OAuth integration by updating environment variables, documentation, and setup instructions. The changes guide users through creating a Google OAuth app, configuring credentials, and updating environment files for both local development and deployment.

**Google Drive OAuth Integration:**

- Added Google Drive OAuth configuration options (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_OAUTH_SCOPES`) to `.env.example` for local development setup.
- Updated `docs/deployment.md` to include instructions for creating a Google Drive OAuth app, obtaining credentials, and setting the necessary environment variables for deployment. [[1]](diffhunk://#diff-7f6254f34e124b6ff67f63aacb73b5252aa8e2b8afe712f48cdd3b32a24f908cR41-R56) [[2]](diffhunk://#diff-7f6254f34e124b6ff67f63aacb73b5252aa8e2b8afe712f48cdd3b32a24f908cR89-R93)

**Documentation Updates:**

- Expanded `contributing.md` with a step-by-step guide for setting up Google OAuth credentials in Google Cloud Console, including enabling the Drive API and configuring redirect URIs.
- Clarified required environment variables for Google Drive OAuth in `contributing.md`, including callback URL details. [[1]](diffhunk://#diff-0b82d9a8fc9c94f7729e7685fca44dd89a479746f7cb14171e6dcdc7beb94387R259-R263) [[2]](diffhunk://#diff-0b82d9a8fc9c94f7729e7685fca44dd89a479746f7cb14171e6dcdc7beb94387R272)