### PR TITLE
Increase mcp timeout

### DIFF
--- a/client/src/lib/mcp-client/client.ts
+++ b/client/src/lib/mcp-client/client.ts
@@ -17,8 +17,8 @@ import type {
 import { BrowserOAuthClientProvider } from './oauth/provider.js';
 import type { SamplingProvider } from './sampling/types.js';
 
-/** Default timeout for MCP tool calls (5 minutes) */
-const DEFAULT_TOOL_TIMEOUT_MS = 5 * 60 * 1000;
+/** Default timeout for MCP tool calls (10 minutes for large Figma files) */
+const DEFAULT_TOOL_TIMEOUT_MS = 10 * 60 * 1000;
 
 /** localStorage keys for reconnection state */
 const LS_SESSION_ID = 'mcp_session_id';


### PR DESCRIPTION
- Increase mcp timeout from 5 to 10 minutes
- The error is thrown by `@modelcontextprotocol/sdk` and captured in the frontend, but it does not stop the steps.
- Slack thread: https://bitovi.slack.com/archives/C096Z489S5V/p1771447001385589