### PR TITLE
feat: OAuth state-based URL preservation and URL parameter support

### DIFF
--- a/client/src/components/ConnectionPanel/ConnectionPanel.tsx
+++ b/client/src/components/ConnectionPanel/ConnectionPanel.tsx
@@ -6,6 +6,7 @@
 
 import { useState } from 'react';
 import type { ConnectionStatus } from '../../lib/mcp-client/index.js';
+import { readUrlParams } from '../../lib/url-params';
 
 interface ConnectionPanelProps {
   status: ConnectionStatus;
@@ -20,9 +21,15 @@ export function ConnectionPanel({
   onDisconnect,
   onRefreshTokens,
 }: ConnectionPanelProps) {
-  const [anthropicKey, setAnthropicKey] = useState(
-    () => localStorage.getItem('mcp_anthropic_key') || ''
-  );
+  const [anthropicKey, setAnthropicKey] = useState(() => {
+    // Priority 1: URL param (for shareable links)
+    const urlParams = readUrlParams();
+    if (urlParams.anthropicKey) {
+      return urlParams.anthropicKey;
+    }
+    // Priority 2: localStorage (persists across refreshes)
+    return localStorage.getItem('mcp_anthropic_key') || '';
+  });
   const [isConnecting, setIsConnecting] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [refreshResult, setRefreshResult] = useState<{ success: boolean; providers: string[]; error?: string } | null>(null);

--- a/client/src/lib/url-params/index.ts
+++ b/client/src/lib/url-params/index.ts
@@ -1,0 +1,13 @@
+/**
+ * URL Parameter Utilities for Form State Restoration
+ * 
+ * Public API for reading and writing URL parameters to enable
+ * shareable URLs with pre-configured tool selections and API keys.
+ * 
+ * @module url-params
+ */
+
+export { readUrlParams } from './reader';
+export { updateUrlWithTool } from './writer';
+export { findToolByKebabName } from './tool-name';
+export type { UrlParamsState } from './types';

--- a/client/src/lib/url-params/reader.ts
+++ b/client/src/lib/url-params/reader.ts
@@ -1,0 +1,17 @@
+/**
+ * Read URL query parameters for form state restoration
+ */
+
+import type { UrlParamsState } from './types';
+
+/**
+ * Read URL parameters from current window location
+ * @returns Object containing anthropicKey and tool parameters if present
+ */
+export function readUrlParams(): UrlParamsState {
+  const params = new URLSearchParams(window.location.search);
+  return {
+    anthropicKey: params.get('anthropicKey') || undefined,
+    tool: params.get('tool') || undefined,
+  };
+}

--- a/client/src/lib/url-params/tool-name.ts
+++ b/client/src/lib/url-params/tool-name.ts
@@ -1,0 +1,19 @@
+/**
+ * Tool lookup utilities
+ * Tools from MCP server are already in kebab-case format (e.g., 'atlassian-get-issue')
+ */
+
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+
+/**
+ * Find tool by name from available tools list
+ * @param toolName - Tool name from URL (already in kebab-case)
+ * @param tools - Available tools from MCP server
+ * @returns Matching tool or undefined if not found
+ * 
+ * @example
+ * findToolByKebabName("atlassian-get-issue", tools) // Tool { name: "atlassian-get-issue", ... }
+ */
+export function findToolByKebabName(toolName: string, tools: Tool[]): Tool | undefined {
+  return tools.find(tool => tool.name === toolName);
+}

--- a/client/src/lib/url-params/types.ts
+++ b/client/src/lib/url-params/types.ts
@@ -1,0 +1,8 @@
+/**
+ * URL parameter types for form state restoration
+ */
+
+export interface UrlParamsState {
+  anthropicKey?: string;
+  tool?: string;
+}

--- a/client/src/lib/url-params/writer.ts
+++ b/client/src/lib/url-params/writer.ts
@@ -1,0 +1,19 @@
+/**
+ * Write URL query parameters for form state sharing
+ * Uses history.replaceState to avoid creating new history entries
+ */
+
+/**
+ * Update URL with tool parameter
+ * Uses history.replaceState to avoid polluting browser history
+ * Note: Tool names from MCP server are already in kebab-case format
+ * @param toolName - Tool name (already in kebab-case from server)
+ * 
+ * @example
+ * updateUrlWithTool("atlassian-get-issue") // URL becomes ?tool=atlassian-get-issue
+ */
+export function updateUrlWithTool(toolName: string): void {
+  const url = new URL(window.location.href);
+  url.searchParams.set('tool', toolName);
+  window.history.replaceState({}, '', url);
+}

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { ConnectionPanel } from '../components/ConnectionPanel/ConnectionPanel';
 import { ToolSelector } from '../components/ToolSelector/ToolSelector';
 import { ToolForm } from '../components/ToolForm/ToolForm';
@@ -7,6 +7,7 @@ import { ResultDisplay } from '../components/ResultDisplay/ResultDisplay';
 import { useConfig } from '../hooks/useConfig';
 import { useMcpClient } from '../hooks/useMcpClient';
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { readUrlParams, findToolByKebabName, updateUrlWithTool } from '../lib/url-params';
 
 export function HomePage() {
   const { loading: configLoading } = useConfig();
@@ -16,6 +17,41 @@ export function HomePage() {
   const [isExecuting, setIsExecuting] = useState(false);
   const [result, setResult] = useState<unknown>(null);
   const [error, setError] = useState<string | undefined>(undefined);
+  const [pendingToolSelection, setPendingToolSelection] = useState<string | null>(null);
+  const [lastUrlTool, setLastUrlTool] = useState<string | null>(null);
+
+  // Read URL and set pending if it's a new tool (handles mount + OAuth callback timing)
+  useEffect(() => {
+    if (state.status === 'connected' && !pendingToolSelection) {
+      const urlParams = readUrlParams();
+      // Only set pending if URL tool is different from what we last attempted
+      if (urlParams.tool && urlParams.tool !== lastUrlTool) {
+        setPendingToolSelection(urlParams.tool);
+        setLastUrlTool(urlParams.tool);
+      }
+    }
+  }, [state.status, pendingToolSelection, lastUrlTool]);
+
+  // Auto-select tool after connection if pending tool name exists
+  useEffect(() => {
+    if (state.status === 'connected' && pendingToolSelection && tools.length > 0) {
+      const tool = findToolByKebabName(pendingToolSelection, tools);
+      if (tool) {
+        setSelectedTool(tool);
+      }
+      // Clear pending selection whether found or not (single attempt)
+      setPendingToolSelection(null);
+    }
+  }, [state.status, pendingToolSelection, tools]);
+
+  // Update URL when tool selection changes (manual tool selection updates URL)
+  useEffect(() => {
+    // Only update URL after connection is established and a tool is selected
+    if (state.status === 'connected' && selectedTool) {
+      updateUrlWithTool(selectedTool.name);
+    }
+    // Note: We NEVER remove the tool parameter from the URL
+  }, [selectedTool, state.status]);
 
   if (configLoading) {
     return (
@@ -28,7 +64,8 @@ export function HomePage() {
   const handleConnect = async (anthropicKey: string) => {
     setResult(null);
     setError(undefined);
-    setSelectedTool(null);
+    // Reset last URL tool to allow auto-selection on connect/reconnect
+    setLastUrlTool(null);
     if (anthropicKey) {
       setAnthropicKey(anthropicKey);
     }
@@ -36,7 +73,8 @@ export function HomePage() {
   };
 
   const handleDisconnect = async () => {
-    setSelectedTool(null);
+    // Don't clear selectedTool - preserve it for reconnect after expiration
+    // URL parameter should stay intact
     setResult(null);
     setError(undefined);
     await disconnect();


### PR DESCRIPTION
- Encode return URL in OAuth state parameter (RFC 6749 compliant)
- Navigate back to original location after OAuth completes
- Add URL parameter library for tool and anthropicKey persistence
- Support shareable URLs: ?tool=<name>&anthropicKey=<key>
- Auto-select tool from URL parameter after connection
- Update URL when tool is manually selected
- Fix ConnectionPanel to restore key from localStorage or URL params

Replaces sessionStorage hack with proper OAuth state parameter that:
- Works across tabs/windows/devices
- Preserves full URL (path + query + hash)
- Server passes state through opaquely
- More reliable than browser storage