### PR TITLE
feat: support PAT headers in MCP flow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -97,7 +97,7 @@ Tools are exposed via **both** MCP protocol and REST API without code duplicatio
 ### Atlassian API Client Pattern
 
 All Atlassian API requests go through `AtlassianClient` (`server/providers/atlassian/atlassian-api-client.ts`):
-- `createAtlassianClient(token)` for OAuth, `createAtlassianClientWithPAT(credentials)` for PAT
+- `createAtlassianClient(token)` for OAuth, `createAtlassianClientWithPAT(credentials)` for PAT, `createAtlassianClientFromAuth(providerAuthInfo, siteName?)` for auto-routing
 - Use `client.getJiraBaseUrl(cloudId)` / `client.getConfluenceBaseUrl(cloudId)` for API URLs
 - Use `resolveCloudId(client, undefined, siteName)` to get cloudId from site name
 

--- a/docs/mcp-pat-headers-setup.md
+++ b/docs/mcp-pat-headers-setup.md
@@ -1,0 +1,158 @@
+# MCP PAT Headers Setup
+
+Use Personal Access Tokens (PATs) to connect MCP clients to Cascade MCP without OAuth. This is the recommended approach for:
+
+- **GitHub Copilot agent** (cloud-hosted, can't do browser OAuth)
+- Other headless/cloud-hosted AI agents
+- Programmatic or scripted MCP clients
+- Local development and testing without OAuth setup
+
+## Prerequisites
+
+You'll need tokens for the providers you want to use. At least one is required.
+
+### Atlassian (Jira/Confluence)
+
+1. Go to https://id.atlassian.com/manage-profile/security/api-tokens
+2. Click **Create API token** and give it a name
+3. Copy the generated token (starts with `ATATT...`)
+4. Base64-encode your credentials:
+   ```bash
+   echo -n "your-email@example.com:ATATT..." | base64
+   ```
+5. The output (e.g., `eW91ci1lbWFpbEBleGFtcGxlLmNvbTpBVEFUVDN4...`) is your `X-Atlassian-Token` value
+
+### Figma
+
+1. Go to https://www.figma.com/settings (scroll to "Personal access tokens")
+2. Generate a new token
+3. Copy the token (starts with `figd_...`) — this is your `X-Figma-Token` value
+
+### Google Drive (Optional)
+
+Google uses encrypted service account credentials. See the [Google Drive Setup Guide](./google-drive-setup.md) for full instructions, then encrypt your credentials at the server's `/encrypt` page. The encrypted string (starts with `RSA-ENCRYPTED:`) is your `X-Google-Token` value.
+
+### Anthropic API Key (for AI-powered tools)
+
+Tools like `write-story` and `analyze-feature-scope` need an LLM. Provide your Anthropic key via the `X-Anthropic-Token` header.
+
+1. Go to https://console.anthropic.com/settings/keys
+2. Create an API key (starts with `sk-ant-...`)
+
+## MCP Client Configuration
+
+### VS Code Copilot
+
+Add to your VS Code `settings.json` (user or workspace):
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "cascade-mcp": {
+        "type": "http",
+        "url": "https://cascade.bitovi.com/mcp",
+        "headers": {
+          "X-Atlassian-Token": "YOUR_BASE64_ENCODED_CREDENTIALS",
+          "X-Figma-Token": "YOUR_FIGMA_PAT",
+          "X-Anthropic-Token": "YOUR_ANTHROPIC_KEY"
+        }
+      }
+    }
+  }
+}
+```
+
+> **Tip:** For local development, use `http://localhost:3000/mcp` as the URL.
+
+### Claude Desktop
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "cascade-mcp": {
+      "type": "streamable-http",
+      "url": "https://cascade.bitovi.com/mcp",
+      "headers": {
+        "X-Atlassian-Token": "YOUR_BASE64_ENCODED_CREDENTIALS",
+        "X-Figma-Token": "YOUR_FIGMA_PAT",
+        "X-Anthropic-Token": "YOUR_ANTHROPIC_KEY"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+Add to your Cursor MCP config (`.cursor/mcp.json` in your project or `~/.cursor/mcp.json` globally):
+
+```json
+{
+  "mcpServers": {
+    "cascade-mcp": {
+      "type": "streamable-http",
+      "url": "https://cascade.bitovi.com/mcp",
+      "headers": {
+        "X-Atlassian-Token": "YOUR_BASE64_ENCODED_CREDENTIALS",
+        "X-Figma-Token": "YOUR_FIGMA_PAT",
+        "X-Anthropic-Token": "YOUR_ANTHROPIC_KEY"
+      }
+    }
+  }
+}
+```
+
+### curl (Testing)
+
+```bash
+curl -X POST https://cascade.bitovi.com/mcp \
+  -H "Content-Type: application/json" \
+  -H "X-Atlassian-Token: YOUR_BASE64_ENCODED_CREDENTIALS" \
+  -H "X-Figma-Token: YOUR_FIGMA_PAT" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "initialize",
+    "params": {
+      "protocolVersion": "2025-03-26",
+      "capabilities": {},
+      "clientInfo": { "name": "test-client", "version": "1.0" }
+    },
+    "id": 1
+  }'
+```
+
+A successful response includes an `mcp-session-id` header — use it for subsequent requests.
+
+## Important Notes
+
+### `siteName` is required for Atlassian tools
+
+When using PAT auth, all Atlassian tools require the `siteName` parameter (e.g., `"bitovi"` from `bitovi.atlassian.net`). The MCP client or LLM will be prompted to provide this when calling tools.
+
+### Auth method is per-session
+
+PAT headers and OAuth cannot be mixed. If a JWT Bearer token is present, PAT headers are ignored. A session is either fully OAuth or fully PAT.
+
+### Google token format
+
+The `X-Google-Token` value must be RSA-encrypted (same format as the REST API). See [Encryption Setup](./encryption-setup.md) for details.
+
+### Only include tokens you need
+
+You only need headers for providers you'll actually use:
+- **Jira-only workflows**: `X-Atlassian-Token` (+ `X-Anthropic-Token` for AI tools)
+- **Figma + Jira workflows**: `X-Atlassian-Token` + `X-Figma-Token` + `X-Anthropic-Token`
+- **Full stack**: All four headers
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| `No Atlassian access token found` | Check that `X-Atlassian-Token` header is present and base64-encoded correctly |
+| `siteName is required` | Pass `siteName` parameter when calling Atlassian tools (e.g., `"bitovi"`) |
+| 401 from Atlassian API | Verify your API token is valid and the email:token are correct before base64 encoding |
+| `No valid Figma access token` | Check that `X-Figma-Token` header is present with a valid `figd_...` token |
+| Tools needing AI fail | Add `X-Anthropic-Token` header with a valid `sk-ant-...` key |

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:watch": "jest --watch",
     "test:e2e": "NODE_OPTIONS='--experimental-vm-modules' jest test/e2e --testTimeout=600000 --runInBand --testMatch='**/test/e2e/**/*.test.ts'",
     "test:e2e:rest-api": "jest test/e2e/api-workflow.test.ts --testTimeout=600000 --runInBand --testMatch='**/test/e2e/**/*.test.ts'",
+    "test:e2e:mcp-pat-auth": "jest test/e2e/mcp-pat-auth.test.ts --testTimeout=600000 --runInBand --testMatch='**/test/e2e/**/*.test.ts'",
     "test:e2e:claude-agent": "NODE_OPTIONS='--experimental-vm-modules' jest test/e2e/claude-agent-review-design.test.ts --testTimeout=600000 --runInBand --testMatch='**/test/e2e/**/*.test.ts'",
     "test:e2e:mcp-sdk:mock": "TEST_USE_MOCK_ATLASSIAN=true jest specs/mcp-sdk --testTimeout=30000 --runInBand --testMatch='**/specs/**/*.test.js' --testMatch='**/specs/**/*.test.ts' --testPathIgnorePatterns='/node_modules/'",
     "validate-pat-tokens": "node --import ./loader.mjs scripts/validate-pat-tokens.ts"

--- a/server/mcp-core/auth-context-store.ts
+++ b/server/mcp-core/auth-context-store.ts
@@ -10,12 +10,13 @@ import { logger } from '../observability/logger.ts';
  */
 export interface ProviderAuthInfo {
   access_token: string;
-  refresh_token: string;
-  expires_at: number;
+  refresh_token?: string;   // Optional: PATs don't have refresh tokens
+  expires_at?: number;      // Optional: PATs don't expire in our store
   scope?: string;
   // Provider-specific optional fields
   cloudId?: string; // Atlassian
   user_id?: string; // Figma
+  authType?: 'oauth' | 'pat';  // Distinguish auth method for downstream routing
 }
 
 /**

--- a/server/mcp-core/auth-helpers.ts
+++ b/server/mcp-core/auth-helpers.ts
@@ -16,6 +16,9 @@ import {
 import { handleJiraAuthError as handleJiraAuthErrorHelper } from '../providers/atlassian/atlassian-helpers.ts';
 import { PROVIDER_KEYS } from '../pkce/token-helpers.js';
 
+// Re-export ProviderAuthInfo for consumers
+export type { ProviderAuthInfo } from './auth-context-store.ts';
+
 /**
  * Helper function to safely log token information without exposing sensitive data
  * @param token - The token to log info about
@@ -46,7 +49,10 @@ let testForcingTokenExpired = false;
  * @returns True if provider token is valid and not expired
  */
 function hasValidProviderToken(provider: ProviderAuthInfo | undefined, now: number): boolean {
-  return provider?.expires_at != null && provider.expires_at > now;
+  if (!provider?.access_token) return false;
+  // PATs don't have expires_at — treat as always valid
+  if (provider.expires_at == null) return true;
+  return provider.expires_at > now;
 }
 
 /**
@@ -119,7 +125,12 @@ export function handleJiraAuthError(response: Response, operation: string = 'Jir
 export function getAuthInfo(context: any): AuthContext | null {
   const authInfo = getAuthInfoFromStore(context);
 
-  if (authInfo && isTokenExpired(authInfo)) {
+  // Skip expiration check for PAT auth — PATs don't have expiration in our store
+  const isPat = authInfo?.atlassian?.authType === 'pat' || 
+                authInfo?.figma?.authType === 'pat' || 
+                authInfo?.google?.authType === 'pat';
+
+  if (authInfo && !isPat && isTokenExpired(authInfo)) {
     throw new InvalidTokenError('The access token expired and re-authentication is needed.');
   }
 

--- a/server/mcp-service.ts
+++ b/server/mcp-service.ts
@@ -294,6 +294,18 @@ async function validateAuthFromRequest(req: Request, res: Response): Promise<Val
     if (errored) { return { authInfo: null, errored: true }; }
   }
   
+  // Fall back to PAT headers
+  if (!authInfo) {
+    authInfo = getAuthInfoFromPatHeaders(req);
+    if (authInfo) {
+      console.log('🔑 Using PAT header authentication', {
+        providers: Object.keys(authInfo).filter(k => 
+          ['atlassian', 'figma', 'google'].includes(k) && authInfo![k as keyof AuthContext]
+        ),
+      });
+    }
+  }
+
   // No auth found anywhere
   if (!authInfo) {
     sendMissingAtlassianAccessToken(res, req, 'anywhere');
@@ -301,6 +313,50 @@ async function validateAuthFromRequest(req: Request, res: Response): Promise<Val
   }
   
   return { authInfo, errored: false };
+}
+
+/**
+ * Extract authentication info from PAT (Personal Access Token) headers.
+ * Supports X-Atlassian-Token, X-Figma-Token, and X-Google-Token headers.
+ * 
+ * @param req - Express request object
+ * @returns AuthContext with PAT credentials, or null if no PAT headers present
+ */
+function getAuthInfoFromPatHeaders(req: Request): AuthContext | null {
+  const atlassianToken = req.headers['x-atlassian-token'] as string | undefined;
+  const figmaToken = req.headers['x-figma-token'] as string | undefined;
+  const googleToken = req.headers['x-google-token'] as string | undefined;
+
+  // At least one provider token must be present
+  if (!atlassianToken && !figmaToken && !googleToken) {
+    return null;
+  }
+
+  const authContext: AuthContext = {};
+
+  if (atlassianToken) {
+    // Atlassian PATs use Basic Auth: base64(email:api_token)
+    authContext.atlassian = {
+      access_token: atlassianToken,
+      authType: 'pat',
+    };
+  }
+
+  if (figmaToken) {
+    authContext.figma = {
+      access_token: figmaToken,
+      authType: 'pat',
+    };
+  }
+
+  if (googleToken) {
+    authContext.google = {
+      access_token: googleToken,
+      authType: 'pat',
+    };
+  }
+
+  return authContext;
 }
 
 /**

--- a/server/providers/atlassian/atlassian-api-client.ts
+++ b/server/providers/atlassian/atlassian-api-client.ts
@@ -161,3 +161,21 @@ export function createAtlassianClientWithPAT(base64Credentials: string, siteName
     },
   };
 }
+
+/**
+ * Create an Atlassian API client from a ProviderAuthInfo object.
+ * Routes to OAuth or PAT client based on authType.
+ * 
+ * @param atlassian - Provider auth info containing access_token and authType
+ * @param siteName - Site name required for PAT auth (e.g., "mycompany" from mycompany.atlassian.net)
+ * @returns AtlassianClient configured for the appropriate auth method
+ */
+export function createAtlassianClientFromAuth(
+  atlassian: { access_token: string; authType?: 'oauth' | 'pat' },
+  siteName?: string,
+): AtlassianClient {
+  if (atlassian.authType === 'pat') {
+    return createAtlassianClientWithPAT(atlassian.access_token, siteName);
+  }
+  return createAtlassianClient(atlassian.access_token);
+}

--- a/server/providers/atlassian/tools/atlassian-add-comment.ts
+++ b/server/providers/atlassian/tools/atlassian-add-comment.ts
@@ -8,7 +8,7 @@
 import { z } from 'zod';
 import { getAuthInfoSafe } from '../../../mcp-core/auth-helpers.js';
 import { resolveCloudId, addIssueComment } from '../atlassian-helpers.js';
-import { createAtlassianClient } from '../atlassian-api-client.js';
+import { createAtlassianClientFromAuth } from '../atlassian-api-client.js';
 import type { McpServer } from '../../../mcp-core/mcp-types.js';
 
 interface AtlassianAddCommentParams {
@@ -52,7 +52,7 @@ export function registerAtlassianAddCommentTool(mcp: McpServer): void {
           };
         }
 
-        const client = createAtlassianClient(token);
+        const client = createAtlassianClientFromAuth(authInfo.atlassian!, siteName);
 
         console.log('  Resolving cloud ID...');
         const siteInfo = await resolveCloudId(client, cloudId, siteName);

--- a/server/providers/atlassian/tools/atlassian-fetch.ts
+++ b/server/providers/atlassian/tools/atlassian-fetch.ts
@@ -13,7 +13,7 @@ import { resolveCloudId, getAuthHeader } from '../atlassian-helpers.ts';
 import { sanitizeObjectWithJWTs } from '../../../tokens.ts';
 import type { McpServer } from '../../../mcp-core/mcp-types.ts';
 import { convertAdfToMarkdown } from '../markdown-converter.ts';
-import { createAtlassianClient } from '../atlassian-api-client.ts';
+import { createAtlassianClientFromAuth } from '../atlassian-api-client.ts';
 
 // Tool parameters interface
 interface FetchParams {
@@ -84,7 +84,7 @@ export function registerAtlassianFetchTool(mcp: McpServer): void {
 
       try {
         // Create Atlassian API client
-        const client = createAtlassianClient(token);
+        const client = createAtlassianClientFromAuth(authInfo.atlassian!, siteName);
         
         // Resolve the target cloud ID using the utility function
         let siteInfo;

--- a/server/providers/atlassian/tools/atlassian-get-attachments.ts
+++ b/server/providers/atlassian/tools/atlassian-get-attachments.ts
@@ -7,7 +7,7 @@ import { logger } from '../../../observability/logger.ts';
 import { getAuthInfoSafe, handleJiraAuthError } from '../../../mcp-core/auth-helpers.ts';
 import { resolveCloudId } from '../atlassian-helpers.ts';
 import type { McpServer } from '../../../mcp-core/mcp-types.ts';
-import { createAtlassianClient } from '../atlassian-api-client.ts';
+import { createAtlassianClientFromAuth } from '../atlassian-api-client.ts';
 
 // Tool parameters interface
 interface GetJiraAttachmentsParams {
@@ -96,7 +96,7 @@ export function registerAtlassianGetAttachmentsTool(mcp: McpServer): void {
 
       try {
         // Create Atlassian API client
-        const client = createAtlassianClient(token);
+        const client = createAtlassianClientFromAuth(authInfo.atlassian!, siteName);
         
         // Resolve the target cloud ID using the utility function
         let siteInfo;

--- a/server/providers/atlassian/tools/atlassian-get-issue.ts
+++ b/server/providers/atlassian/tools/atlassian-get-issue.ts
@@ -9,7 +9,7 @@ import { resolveCloudId } from '../atlassian-helpers.ts';
 import { sanitizeObjectWithJWTs } from '../../../tokens.ts';
 import type { McpServer } from '../../../mcp-core/mcp-types.ts';
 import { getJiraIssue } from '../atlassian-helpers.ts';
-import { createAtlassianClient } from '../atlassian-api-client.ts';
+import { createAtlassianClientFromAuth } from '../atlassian-api-client.ts';
 import type { JiraIssue } from '../types.ts';
 
 // Tool parameters interface
@@ -73,7 +73,7 @@ export function registerAtlassianGetIssueTool(mcp: McpServer): void {
 
       try {
         // Create Atlassian API client
-        const client = createAtlassianClient(token);
+        const client = createAtlassianClientFromAuth(authInfo.atlassian!, siteName);
         
         // Resolve the target cloud ID using the utility function
         let siteInfo;

--- a/server/providers/atlassian/tools/atlassian-search.ts
+++ b/server/providers/atlassian/tools/atlassian-search.ts
@@ -12,7 +12,7 @@ import { getAuthInfoSafe, handleJiraAuthError } from '../../../mcp-core/auth-hel
 import { resolveCloudId, getAuthHeader } from '../atlassian-helpers.ts';
 import { sanitizeObjectWithJWTs } from '../../../tokens.ts';
 import type { McpServer } from '../../../mcp-core/mcp-types.ts';
-import { createAtlassianClient } from '../atlassian-api-client.ts';
+import { createAtlassianClientFromAuth } from '../atlassian-api-client.ts';
 
 // Tool parameters interface
 interface SearchParams {
@@ -87,7 +87,7 @@ export function registerAtlassianSearchTool(mcp: McpServer): void {
 
       try {
         // Create Atlassian API client
-        const client = createAtlassianClient(token);
+        const client = createAtlassianClientFromAuth(authInfo.atlassian!, siteName);
         
         // Resolve the target cloud ID using the utility function
         let siteInfo;

--- a/server/providers/atlassian/tools/atlassian-update-comment.ts
+++ b/server/providers/atlassian/tools/atlassian-update-comment.ts
@@ -9,7 +9,7 @@
 import { z } from 'zod';
 import { getAuthInfoSafe } from '../../../mcp-core/auth-helpers.js';
 import { resolveCloudId, updateIssueComment } from '../atlassian-helpers.js';
-import { createAtlassianClient } from '../atlassian-api-client.js';
+import { createAtlassianClientFromAuth } from '../atlassian-api-client.js';
 import type { McpServer } from '../../../mcp-core/mcp-types.js';
 
 interface AtlassianUpdateCommentParams {
@@ -56,7 +56,7 @@ export function registerAtlassianUpdateCommentTool(mcp: McpServer): void {
           };
         }
 
-        const client = createAtlassianClient(token);
+        const client = createAtlassianClientFromAuth(authInfo.atlassian!, siteName);
 
         console.log('  Resolving cloud ID...');
         const siteInfo = await resolveCloudId(client, cloudId, siteName);

--- a/server/providers/atlassian/tools/atlassian-update-issue-description.ts
+++ b/server/providers/atlassian/tools/atlassian-update-issue-description.ts
@@ -4,7 +4,7 @@ import { getAuthInfoSafe, handleJiraAuthError } from '../../../mcp-core/auth-hel
 import { resolveCloudId } from '../atlassian-helpers.ts';
 import { convertMarkdownToAdf, validateAdf, type ADFDocument } from '../markdown-converter.ts';
 import type { McpServer } from '../../../mcp-core/mcp-types.ts';
-import { createAtlassianClient } from '../atlassian-api-client.ts';
+import { createAtlassianClientFromAuth } from '../atlassian-api-client.ts';
 
 // Tool parameters interface
 interface UpdateIssueDescriptionParams {
@@ -94,7 +94,7 @@ export function registerAtlassianUpdateIssueDescriptionTool(mcp: McpServer): voi
         }
 
         // Create Atlassian API client
-        const client = createAtlassianClient(token);
+        const client = createAtlassianClientFromAuth(authInfo.atlassian!, siteName);
         
         // Resolve the target cloud ID
         let siteInfo;

--- a/server/providers/atlassian/tools/confluence-analyze-page.ts
+++ b/server/providers/atlassian/tools/confluence-analyze-page.ts
@@ -14,7 +14,8 @@ import { z } from 'zod';
 import { logger } from '../../../observability/logger.ts';
 import { getAuthInfoSafe } from '../../../mcp-core/auth-helpers.ts';
 import type { McpServer } from '../../../mcp-core/mcp-types.ts';
-import { createAtlassianClient } from '../atlassian-api-client.ts';
+import { createAtlassianClientFromAuth } from '../atlassian-api-client.ts';
+import type { ProviderAuthInfo } from '../../../mcp-core/auth-helpers.ts';
 import { convertAdfNodesToMarkdown } from '../markdown-converter.ts';
 import { createMcpLLMClient, type McpToolContext } from '../../../llm-client/mcp-sampling-client.ts';
 import { createQueuedGenerateText } from '../../../llm-client/queued-generate-text.ts';
@@ -115,7 +116,7 @@ interface AnalyzePageResult {
  */
 async function analyzeConfluencePage(
   params: AnalyzePageParams,
-  atlassianToken: string,
+  atlassianAuth: ProviderAuthInfo,
   generateText: GenerateTextFn
 ): Promise<AnalyzePageResult> {
   const result: AnalyzePageResult = {
@@ -138,7 +139,7 @@ async function analyzeConfluencePage(
 
     // Handle short links
     if (parsed.wasShortLink) {
-      const client = createAtlassianClient(atlassianToken);
+      const client = createAtlassianClientFromAuth(atlassianAuth, parsed.siteName);
       const resolved = await resolveConfluenceShortLink(client, parsed);
       if (!resolved) {
         result.parseError = `Could not resolve short link: ${params.pageUrl}`;
@@ -165,7 +166,7 @@ async function analyzeConfluencePage(
 
   // Step 2: Fetch page from Confluence API
   console.log(`  📄 Fetching Confluence page: ${pageId} from ${siteName}`);
-  const client = createAtlassianClient(atlassianToken);
+  const client = createAtlassianClientFromAuth(atlassianAuth, siteName);
 
   let pageData: ConfluencePageData;
   try {
@@ -470,7 +471,7 @@ export function registerConfluenceAnalyzePageTool(mcp: McpServer): void {
       const generateText = createQueuedGenerateText(createMcpLLMClient(context as McpToolContext));
 
       try {
-        const result = await analyzeConfluencePage(params, token, generateText);
+        const result = await analyzeConfluencePage(params, authInfo.atlassian!, generateText);
         const formattedOutput = formatAnalysisResult(result);
 
         return {

--- a/server/providers/combined/tools/analyze-feature-scope/analyze-feature-scope.ts
+++ b/server/providers/combined/tools/analyze-feature-scope/analyze-feature-scope.ts
@@ -11,7 +11,7 @@
 import { z } from 'zod';
 import type { McpServer } from '../../../../mcp-core/mcp-types.js';
 import { getAuthInfoSafe } from '../../../../mcp-core/auth-helpers.js';
-import { createAtlassianClient } from '../../../atlassian/atlassian-api-client.js';
+import { createAtlassianClientFromAuth } from '../../../atlassian/atlassian-api-client.js';
 import { createFigmaClient } from '../../../figma/figma-api-client.js';
 import { createGoogleClient } from '../../../google/google-api-client.js';
 import { createMcpLLMClient } from '../../../../llm-client/mcp-sampling-client.js';
@@ -101,7 +101,7 @@ export function registerAnalyzeFeatureScopeTool(mcp: McpServer): void {
 
       try {
         // Create API clients with tokens
-        const atlassianClient = createAtlassianClient(atlassianToken);
+        const atlassianClient = createAtlassianClientFromAuth(authInfo.atlassian!, siteName);
         const figmaClient = createFigmaClient(figmaToken);
         const googleClient = googleToken ? createGoogleClient(googleToken) : undefined;
         const generateText = createQueuedGenerateText(createMcpLLMClient(context));

--- a/server/providers/combined/tools/extract-linked-resources/extract-linked-resources.ts
+++ b/server/providers/combined/tools/extract-linked-resources/extract-linked-resources.ts
@@ -12,7 +12,7 @@
 import { z } from 'zod';
 import { logger } from '../../../../observability/logger.ts';
 import { getAuthInfoSafe } from '../../../../mcp-core/auth-helpers.ts';
-import { createAtlassianClient } from '../../../atlassian/atlassian-api-client.ts';
+import { createAtlassianClientFromAuth } from '../../../atlassian/atlassian-api-client.ts';
 import { resolveCloudId, getJiraIssue } from '../../../atlassian/atlassian-helpers.ts';
 import { convertAdfToMarkdown } from '../../../atlassian/markdown-converter.ts';
 import { extractAllUrlsFromADF } from '../../../atlassian/adf-utils.ts';
@@ -158,7 +158,7 @@ async function handleJiraUrl(
     return textResult(`Error: Could not determine site name from URL: ${url}. Please provide siteName parameter.`);
   }
 
-  const client = createAtlassianClient(token);
+  const client = createAtlassianClientFromAuth(authInfo.atlassian!, siteName);
   const siteInfo = await resolveCloudId(client, undefined, siteName);
   const cloudId = siteInfo.cloudId;
 
@@ -289,7 +289,7 @@ async function handleConfluenceUrl(
   }
 
   const siteName = siteNameOverride || parsed.siteName;
-  const client = createAtlassianClient(token);
+  const client = createAtlassianClientFromAuth(authInfo.atlassian!, siteName);
 
   // Resolve short links if needed
   let pageInfo = parsed;

--- a/server/providers/combined/tools/review-work-item/review-work-item.ts
+++ b/server/providers/combined/tools/review-work-item/review-work-item.ts
@@ -9,7 +9,7 @@
 import { z } from 'zod';
 import type { McpServer } from '../../../../mcp-core/mcp-types.js';
 import { getAuthInfoSafe } from '../../../../mcp-core/auth-helpers.js';
-import { createAtlassianClient } from '../../../atlassian/atlassian-api-client.js';
+import { createAtlassianClientFromAuth } from '../../../atlassian/atlassian-api-client.js';
 import { createFigmaClient } from '../../../figma/figma-api-client.js';
 import { createMcpLLMClient } from '../../../../llm-client/mcp-sampling-client.js';
 import { createQueuedGenerateText } from '../../../../llm-client/queued-generate-text.js';
@@ -75,7 +75,7 @@ export function registerReviewWorkItemTool(mcp: McpServer): void {
 
       try {
         // Create API clients with tokens
-        const atlassianClient = createAtlassianClient(atlassianToken);
+        const atlassianClient = createAtlassianClientFromAuth(authInfo.atlassian!, siteName);
         const figmaClient = figmaToken ? createFigmaClient(figmaToken) : createFigmaClient(''); // Figma optional
         const generateText = createQueuedGenerateText(createMcpLLMClient(context));
         const notify = createProgressNotifier(context, 6); // 6 phases total

--- a/server/providers/combined/tools/write-next-story/write-next-story.ts
+++ b/server/providers/combined/tools/write-next-story/write-next-story.ts
@@ -8,7 +8,7 @@
 import { z } from 'zod';
 import type { McpServer } from '../../../../mcp-core/mcp-types.js';
 import { getAuthInfoSafe } from '../../../../mcp-core/auth-helpers.js';
-import { createAtlassianClient } from '../../../atlassian/atlassian-api-client.js';
+import { createAtlassianClientFromAuth } from '../../../atlassian/atlassian-api-client.js';
 import { createFigmaClient } from '../../../figma/figma-api-client.js';
 import { createGoogleClient } from '../../../google/google-api-client.js';
 import { createMcpLLMClient } from '../../../../llm-client/mcp-sampling-client.js';
@@ -75,7 +75,7 @@ export function registerWriteNextStoryTool(mcp: McpServer): void {
 
       try {
         // Create API clients with tokens captured in closures
-        const atlassianClient = createAtlassianClient(atlassianToken);
+        const atlassianClient = createAtlassianClientFromAuth(authInfo.atlassian!, siteName);
         const figmaClient = createFigmaClient(figmaToken);
         const googleClient = googleToken ? createGoogleClient(googleToken) : undefined;
         const generateText = createQueuedGenerateText(createMcpLLMClient(context));

--- a/server/providers/combined/tools/write-story-context/write-story-context.ts
+++ b/server/providers/combined/tools/write-story-context/write-story-context.ts
@@ -8,7 +8,7 @@
 import { z } from 'zod';
 import type { McpServer } from '../../../../mcp-core/mcp-types.js';
 import { getAuthInfoSafe } from '../../../../mcp-core/auth-helpers.js';
-import { createAtlassianClient } from '../../../atlassian/atlassian-api-client.js';
+import { createAtlassianClientFromAuth } from '../../../atlassian/atlassian-api-client.js';
 import { logger } from '../../../../observability/logger.js';
 import { executeWriteStoryContext } from './core-logic.js';
 
@@ -61,7 +61,7 @@ export function registerWriteStoryContextTool(mcp: McpServer): void {
           };
         }
 
-        const atlassianClient = createAtlassianClient(atlassianToken);
+        const atlassianClient = createAtlassianClientFromAuth(authInfo.atlassian!, siteName);
 
         // Execute core logic
         const result = await executeWriteStoryContext(

--- a/server/providers/combined/tools/write-story/write-story.ts
+++ b/server/providers/combined/tools/write-story/write-story.ts
@@ -11,7 +11,7 @@
 import { z } from 'zod';
 import type { McpServer } from '../../../../mcp-core/mcp-types.js';
 import { getAuthInfoSafe } from '../../../../mcp-core/auth-helpers.js';
-import { createAtlassianClient } from '../../../atlassian/atlassian-api-client.js';
+import { createAtlassianClientFromAuth } from '../../../atlassian/atlassian-api-client.js';
 import { createFigmaClient } from '../../../figma/figma-api-client.js';
 import { createGoogleClient } from '../../../google/google-api-client.js';
 import { createMcpLLMClient } from '../../../../llm-client/mcp-sampling-client.js';
@@ -82,7 +82,7 @@ export function registerWriteStoryTool(mcp: McpServer): void {
 
       try {
         // Create API clients with tokens captured in closures
-        const atlassianClient = createAtlassianClient(atlassianToken);
+        const atlassianClient = createAtlassianClientFromAuth(authInfo.atlassian!, siteName);
         const figmaClient = figmaToken ? createFigmaClient(figmaToken) : undefined;
         const googleClient = googleToken ? createGoogleClient(googleToken) : undefined;
         const generateText = createQueuedGenerateText(createMcpLLMClient(context));

--- a/server/providers/combined/tools/writing-shell-stories/write-shell-stories.ts
+++ b/server/providers/combined/tools/writing-shell-stories/write-shell-stories.ts
@@ -15,7 +15,7 @@
 import { z } from 'zod';
 import type { McpServer } from '../../../../mcp-core/mcp-types.js';
 import { getAuthInfoSafe } from '../../../../mcp-core/auth-helpers.js';
-import { createAtlassianClient } from '../../../atlassian/atlassian-api-client.js';
+import { createAtlassianClientFromAuth } from '../../../atlassian/atlassian-api-client.js';
 import { createFigmaClient } from '../../../figma/figma-api-client.js';
 import { createGoogleClient } from '../../../google/google-api-client.js';
 import { createMcpLLMClient } from '../../../../llm-client/mcp-sampling-client.js';
@@ -94,7 +94,7 @@ export function registerWriteShellStoriesTool(mcp: McpServer): void {
 
       try {
         // Create API clients with tokens captured in closures
-        const atlassianClient = createAtlassianClient(atlassianToken);
+        const atlassianClient = createAtlassianClientFromAuth(authInfo.atlassian!, siteName);
         const figmaClient = createFigmaClient(figmaToken);
         const googleClient = googleToken ? createGoogleClient(googleToken) : undefined;
         const generateText = createQueuedGenerateText(createMcpLLMClient(context));

--- a/server/readme.md
+++ b/server/readme.md
@@ -183,11 +183,12 @@ npm run dev:client
   Creates pre-configured clients for making authenticated Atlassian API requests.
   - `createAtlassianClient(accessToken)` - OAuth client (routes through api.atlassian.com gateway)
   - `createAtlassianClientWithPAT(base64Credentials)` - PAT client (direct site URLs)
+  - `createAtlassianClientFromAuth(providerAuthInfo, siteName?)` - Routes to OAuth or PAT client based on `authType`
   - `client.fetch(url, options)` - Makes authenticated requests with token in closure
   - `client.getJiraBaseUrl(cloudId)` - Returns Jira API base URL for cloud ID
   - `client.getConfluenceBaseUrl(cloudId)` - Returns Confluence API base URL for cloud ID
   - *Note*: OAuth tokens **must** route through `api.atlassian.com/ex/{product}/{cloudId}/` gateway
-  - *Example*: `const client = createAtlassianClient(token); await client.fetch(client.getJiraBaseUrl(cloudId) + '/issue/PROJ-123')`
+  - *Example*: `const client = createAtlassianClientFromAuth(authInfo.atlassian, siteName); await client.fetch(client.getJiraBaseUrl(cloudId) + '/issue/PROJ-123')`
 
 - **providers/atlassian/markdown-converter.ts** - Markdown ↔ ADF Conversion  
   Converts between Markdown and ADF (Atlassian Document Format) for Jira descriptions.
@@ -653,6 +654,44 @@ plugins/cascade-mcp/
 4. Results posted via `figma-post-comment`, `atlassian-add-comment`, or `atlassian-update-issue-description`
 
 ## Key Authentication Patterns
+
+### MCP PAT Authentication (Personal Access Tokens)
+
+MCP clients can authenticate using Personal Access Tokens via HTTP headers instead of the OAuth PKCE flow. This enables headless/cloud-hosted AI agents (e.g., GitHub Copilot agent), programmatic MCP clients, and simpler local development.
+
+**Supported headers:**
+- `X-Atlassian-Token` — Base64-encoded `email:api_token` for Jira/Confluence
+- `X-Figma-Token` — Figma personal access token
+- `X-Google-Token` — RSA-encrypted Google service account JSON
+
+At least one provider token must be present. PAT auth bypasses the OAuth PKCE flow entirely.
+
+**Auth fallback chain:** JWT Bearer → Query param JWT → PAT headers. If a JWT is present, PAT headers are ignored. A session is either fully OAuth or fully PAT.
+
+**Key differences from OAuth:**
+- PATs don't expire in the auth store (no `expires_at` / `refresh_token`)
+- Invalid PATs return tool errors, not `WWW-Authenticate` 401s (no OAuth re-auth flow)
+- Atlassian PATs require `siteName` in tool parameters (PAT clients use `{siteName}.atlassian.net` directly instead of the OAuth API gateway)
+
+**Example: Initialize an MCP session with PATs:**
+```bash
+curl -X POST http://localhost:3000/mcp \
+  -H "Content-Type: application/json" \
+  -H "X-Atlassian-Token: base64(email:api_token)" \
+  -H "X-Figma-Token: figd_..." \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "initialize",
+    "params": {
+      "protocolVersion": "2025-03-26",
+      "capabilities": {},
+      "clientInfo": { "name": "my-client", "version": "1.0" }
+    },
+    "id": 1
+  }'
+```
+
+**Internal routing:** MCP tools use `createAtlassianClientFromAuth(authInfo.atlassian, siteName)` which automatically selects `Bearer` auth (OAuth) or `Basic` auth (PAT) based on `authType`.
 
 ### Environment Variables
 

--- a/specs/069-mcp-pat-headers.md
+++ b/specs/069-mcp-pat-headers.md
@@ -1,0 +1,368 @@
+# 069 — Support PAT Headers in MCP Flow
+
+## Goal
+
+Allow MCP clients to authenticate using Personal Access Tokens (PATs) via HTTP headers — the same `X-Atlassian-Token`, `X-Figma-Token`, and `X-Google-Token` headers that the REST API already accepts — instead of requiring the OAuth PKCE flow.
+
+**Primary use case:** GitHub's cloud-hosted Copilot agent (running on GitHub's servers) cannot perform browser-based OAuth redirects. It needs a way to pass user-provided PATs to CascadeMCP over the MCP protocol so it can call tools like `write-story`, `analyze-feature-scope`, etc. on behalf of the user.
+
+This also enables:
+- Other headless/cloud-hosted AI agents that can't do browser OAuth
+- Programmatic/scripted MCP clients
+- Simpler local development and testing without OAuth setup
+- CI/CD pipelines using MCP directly
+
+## Current State
+
+### MCP Auth (OAuth only)
+- `validateAuthFromRequest()` in `server/mcp-service.ts` only accepts a JWT (from `Authorization: Bearer <JWT>` or `?token=<JWT>`)
+- JWT is produced by the PKCE OAuth flow and embeds provider tokens in its payload: `{ atlassian: { access_token, refresh_token, expires_at }, figma: { ... }, google: { ... } }`
+- Auth context is stored per-session as an `AuthContext` object with nested `ProviderAuthInfo` per provider
+- `ProviderAuthInfo` currently requires `refresh_token: string` and `expires_at: number` — PATs have neither
+
+### REST API Auth (PAT headers)
+- REST API handlers read `X-Atlassian-Token`, `X-Figma-Token`, `X-Google-Token` from request headers
+- They construct provider-specific clients directly (e.g., `createAtlassianClientWithPAT(base64Credentials, siteName)`)
+- They bypass `AuthContext`/`ProviderAuthInfo` entirely — each handler creates its own clients
+
+### Key Difference
+MCP tools use `getAuthInfoSafe(context)` → `AuthContext` → `provider.access_token` to build API clients.  
+REST API handlers read headers directly and build clients themselves.  
+To support PATs in MCP, we need to bridge the gap: construct a synthetic `AuthContext` from PAT headers so all existing MCP tools continue working unchanged.
+
+## Implementation Plan
+
+### Step 1: Make `ProviderAuthInfo` compatible with PATs
+
+**File:** `server/mcp-core/auth-context-store.ts`
+
+Make `refresh_token` and `expires_at` optional since PATs don't have these:
+
+```typescript
+export interface ProviderAuthInfo {
+  access_token: string;
+  refresh_token?: string;   // was: string (required)
+  expires_at?: number;      // was: number (required)
+  scope?: string;
+  cloudId?: string;
+  user_id?: string;
+  authType?: 'oauth' | 'pat';  // new: distinguish for downstream use
+}
+```
+
+**How to verify:** TypeScript compiles. Existing OAuth flow still works (refresh_token and expires_at are always present for OAuth tokens). Run e2e tests.
+
+### Step 2: Update `isTokenExpired` to handle missing `expires_at`
+
+**File:** `server/mcp-core/auth-helpers.ts`
+
+The `hasValidProviderToken()` helper currently checks `provider.expires_at != null && provider.expires_at > now`. PATs have no `expires_at`, so they'd incorrectly appear expired.
+
+Update to treat missing `expires_at` as "never expires":
+
+```typescript
+function hasValidProviderToken(provider: ProviderAuthInfo | undefined, now: number): boolean {
+  if (!provider?.access_token) return false;
+  // PATs don't have expires_at — treat as always valid
+  if (provider.expires_at == null) return true;
+  return provider.expires_at > now;
+}
+```
+
+**How to verify:** Write a unit test: a `ProviderAuthInfo` without `expires_at` should not be considered expired. Existing OAuth tokens with `expires_at` still expire correctly.
+
+### Step 3: Add PAT extraction helper to `mcp-service.ts`
+
+**File:** `server/mcp-service.ts`
+
+Add a new function `getAuthInfoFromPatHeaders()` that reads the PAT headers and constructs a synthetic `AuthContext`:
+
+```typescript
+function getAuthInfoFromPatHeaders(req: Request): AuthContext | null {
+  const atlassianToken = req.headers['x-atlassian-token'] as string | undefined;
+  const figmaToken = req.headers['x-figma-token'] as string | undefined;
+  const googleToken = req.headers['x-google-token'] as string | undefined;
+
+  // At least one provider token must be present
+  if (!atlassianToken && !figmaToken && !googleToken) {
+    return null;
+  }
+
+  const authContext: AuthContext = {};
+
+  if (atlassianToken) {
+    // Atlassian PATs use Basic Auth: base64(email:api_token)
+    // The existing AtlassianClient expects an access_token for OAuth,
+    // but for PATs we store the raw base64 credentials
+    authContext.atlassian = {
+      access_token: atlassianToken,
+      authType: 'pat',
+    };
+  }
+
+  if (figmaToken) {
+    authContext.figma = {
+      access_token: figmaToken,
+      authType: 'pat',
+    };
+  }
+
+  if (googleToken) {
+    authContext.google = {
+      access_token: googleToken,
+      authType: 'pat',
+    };
+  }
+
+  return authContext;
+}
+```
+
+**How to verify:** Unit test: passing `X-Atlassian-Token: abc123` produces an `AuthContext` with `atlassian.access_token === 'abc123'` and `atlassian.authType === 'pat'`.
+
+### Step 4: Wire PAT extraction into `validateAuthFromRequest`
+
+**File:** `server/mcp-service.ts`
+
+Update the `validateAuthFromRequest()` function to try PAT headers as a third fallback:
+
+```typescript
+async function validateAuthFromRequest(req: Request, res: Response): Promise<ValidationResult> {
+  // Try bearer token (JWT from OAuth) first
+  let { authInfo, errored } = await getAuthInfoFromBearer(req, res);
+  if (errored) { return { authInfo: null, errored: true }; }
+
+  // Fall back to query param JWT
+  if (!authInfo) {
+    ({ authInfo, errored } = await getAuthInfoFromQueryToken(req, res));
+    if (errored) { return { authInfo: null, errored: true }; }
+  }
+
+  // Fall back to PAT headers
+  if (!authInfo) {
+    authInfo = getAuthInfoFromPatHeaders(req);
+    if (authInfo) {
+      console.log('🔑 Using PAT header authentication', {
+        providers: Object.keys(authInfo).filter(k => 
+          ['atlassian', 'figma', 'google'].includes(k) && authInfo![k as keyof AuthContext]
+        ),
+      });
+    }
+  }
+
+  // No auth found anywhere
+  if (!authInfo) {
+    sendMissingAtlassianAccessToken(res, req, 'anywhere');
+    return { authInfo: null, errored: true };
+  }
+
+  return { authInfo, errored: false };
+}
+```
+
+**How to verify:** Start the server locally. Send a POST to `/mcp` with an `initialize` body and `X-Atlassian-Token` + `X-Figma-Token` headers (no JWT). Confirm the server initializes a session successfully (returns `mcp-session-id`).
+
+### Step 5: Handle PAT auth in downstream API clients
+
+**The Atlassian Problem:** MCP tools call `createAtlassianClient(access_token)` which uses `Authorization: Bearer <token>` (OAuth). But PATs need `Authorization: Basic <base64>` (`createAtlassianClientWithPAT`). The `access_token` stored in `ProviderAuthInfo` for PATs is the base64-encoded `email:api_token`, not an OAuth access token.
+
+**File:** `server/providers/atlassian/atlassian-api-client.ts`
+
+Add a new `createAtlassianClientFromAuth()` helper that accepts `ProviderAuthInfo` and routes internally. The existing `createAtlassianClient` is left unchanged:
+
+```typescript
+export function createAtlassianClientFromAuth(
+  atlassian: ProviderAuthInfo,
+  siteName?: string,
+): AtlassianClient {
+  if (atlassian.authType === 'pat') {
+    return createAtlassianClientWithPAT(atlassian.access_token, siteName);
+  }
+  return createAtlassianClient(atlassian.access_token);
+}
+```
+
+**File:** All MCP tool call sites (~10 files)
+
+Find all call sites of `createAtlassianClient(authInfo.atlassian.access_token)` and replace with `createAtlassianClientFromAuth`:
+
+```typescript
+// Before
+const client = createAtlassianClient(authInfo.atlassian.access_token);
+
+// After
+const client = createAtlassianClientFromAuth(authInfo.atlassian, siteName);
+```
+
+`siteName` comes from the tool's existing input parameter (already accepted by all these tools). For OAuth sessions `siteName` is optional and may be `undefined`; for PAT sessions `createAtlassianClientWithPAT` will throw if it's missing, giving a clear error.
+
+> **Note:** The `resolveCloudId` call in each tool already handles PAT vs OAuth routing — `resolveCloudId(client, cloudId, siteName)` for PAT clients hits `_edge/tenant_info` using `siteName`. No changes needed there.
+
+**For Figma:** Figma PATs work the same as OAuth tokens (both use `Authorization: Bearer <token>`). No client changes needed.
+
+**For Google:** Google PATs use encrypted service account JSON, not access tokens. This requires the existing `parseOptionalGoogleToken()` / decryption flow from the REST API. Re-use that same decryption logic.
+
+**How to verify:** Using a PAT token, call a simple MCP tool like `atlassian-get-sites` and confirm it works. For Atlassian, the response from the tenant_info endpoint should return the cloudId. For Figma, `figma-get-user` should return user info.
+
+### Step 6: Handle siteName resolution for PAT-based Atlassian requests
+
+**Problem:** OAuth Atlassian clients use `api.atlassian.com/ex/jira/{cloudId}` which doesn't need a siteName. PAT clients need `{siteName}.atlassian.net` which requires knowing the siteName.
+
+**Current pattern:** MCP tools already accept `siteName` as a tool input parameter (e.g., `write-story` has `siteName?: string`). The REST API also takes `siteName` in the request body — there is no `X-Atlassian-Site` header.
+
+**Options (pick one):**
+
+**Option A: Rely on existing `siteName` tool parameter (recommended)**  
+No new header needed. Tools already pass `siteName` to `createAtlassianClient` / `resolveCloudId`. For PAT auth, the tool just needs to ensure `siteName` is provided (required instead of optional).
+
+**Option B: Add an `X-Atlassian-Site` header**  
+Store siteName on the `AuthContext` at session creation so tools don't need to pass it per-call. More convenient but adds a new header that doesn't exist in the REST API pattern.
+
+Recommendation: **Option A** — no changes needed to the auth layer. Just make `siteName` required when `authType === 'pat'` at the tool validation level.
+
+### Step 7: Skip `WWW-Authenticate` / OAuth re-auth for PAT sessions
+
+**File:** `server/mcp-core/auth-helpers.ts`
+
+When a PAT-based tool gets a 401 from a provider API, it should NOT throw `InvalidTokenError` (which triggers OAuth re-auth). Instead, it should return a clear error message that the PAT is invalid/expired.
+
+Add a check in `getAuthInfo()`:
+
+```typescript
+export function getAuthInfo(context: any): AuthContext | null {
+  const authInfo = getAuthInfoFromStore(context);
+
+  // Skip expiration check for PAT auth — PATs don't have expiration in our store
+  const isPat = authInfo?.atlassian?.authType === 'pat' || 
+                authInfo?.figma?.authType === 'pat' || 
+                authInfo?.google?.authType === 'pat';
+  
+  if (authInfo && !isPat && isTokenExpired(authInfo)) {
+    throw new InvalidTokenError('The access token expired and re-authentication is needed.');
+  }
+
+  return authInfo;
+}
+```
+
+**How to verify:** Use an invalid PAT. Confirm you get a tool error (not a 401 with `WWW-Authenticate` that triggers an OAuth popup).
+
+### Step 8: Update documentation
+
+**File:** `server/readme.md`
+
+Add a section documenting PAT authentication for MCP:
+
+- List the supported headers: `X-Atlassian-Token`, `X-Figma-Token`, `X-Google-Token`, `X-Atlassian-Site`
+- Note that PAT auth bypasses OAuth PKCE entirely
+- Note that at least one provider token must be present
+- Include an example curl command for initializing an MCP session with PATs
+
+**How to verify:** Follow the documentation to set up a PAT-authenticated MCP session from scratch.
+
+## Summary of Files Changed
+
+| File | Change |
+|------|--------|
+| `server/mcp-core/auth-context-store.ts` | Make `refresh_token`, `expires_at` optional; add `authType` field |
+| `server/mcp-core/auth-helpers.ts` | Handle missing `expires_at`; skip OAuth re-auth for PATs |
+| `server/mcp-service.ts` | Add `getAuthInfoFromPatHeaders()`; wire into `validateAuthFromRequest()` |
+| `server/providers/atlassian/atlassian-api-client.ts` | Route to PAT client based on `authType` |
+| MCP tool call sites | Replace `createAtlassianClient(token)` with `createAtlassianClientFromAuth(authInfo.atlassian, siteName)` |
+| `server/readme.md` | Document PAT authentication for MCP |
+
+## Questions
+
+1. For Atlassian PAT auth, should `siteName` come from: (A) the existing `siteName` tool parameter — already accepted by most tools, no auth-layer changes needed, or (B) a new `X-Atlassian-Site` header stored on the session — more convenient so it doesn't need to be passed per tool call? 
+
+Leaning toward Option A since it matches how tools already work.
+
+2. Should PAT auth be allowed in production, or only when an env var like `ALLOW_MCP_PAT_AUTH=true` is set? (Security consideration: PATs in headers could be logged by proxies.)
+
+A: In production.  No env var. 
+
+3. For the Google token: the REST API expects `X-Google-Token` to be RSA-encrypted service account JSON. Should MCP PAT auth use the same encrypted format, or also support raw service account JSON for simpler local dev?
+
+Yes, same format.
+
+4. Should we support mixing OAuth + PAT in the same session? (e.g., OAuth for Atlassian, PAT for Figma.)
+
+A: No. The fallback chain in `validateAuthFromRequest()` (JWT → query JWT → PAT headers) means only one auth method is used per request — they aren't merged. If a JWT is present, PAT headers are ignored. A session is either fully OAuth or fully PAT. No OAuth flow should be triggered for PAT sessions.
+
+
+
+5. The `createAtlassianClient()` call sites need to be updated to pass `authType` and `siteName`. There are ~10 MCP tool call sites (e.g., `analyze-feature-scope.ts`, `extract-linked-resources.ts`, `confluence-analyze-page.ts`, `atlassian-update-issue-description.ts`, etc.).
+
+**Where `siteName` comes from:** Every tool already accepts `siteName` as an optional input parameter from the LLM/caller (e.g. `"bitovi"` from `bitovi.atlassian.net`). Today, it's passed to `resolveCloudId(client, cloudId, siteName)` — which for PAT clients already uses it to hit `https://{siteName}.atlassian.net/_edge/tenant_info` to fetch the cloudId. For the PAT client creation itself, `siteName` is also needed at construction time because the base URL is `https://{siteName}.atlassian.net/rest/api/3/` (not the OAuth gateway). So `siteName` flows: LLM input → tool params → both `createAtlassianClientFromAuth` (for PAT) and `resolveCloudId`.
+
+A: **Option B** — add `createAtlassianClientFromAuth(atlassian: ProviderAuthInfo, siteName?)` that handles routing internally. Call sites pass the whole `ProviderAuthInfo` object; routing logic is centralized; existing `createAtlassianClient` is unchanged.
+
+Details for the two options considered:
+
+**Option A: Update each call site to pass explicit parameters**
+
+Change the `createAtlassianClient` signature to accept `authType` and `siteName`:
+
+```typescript
+// atlassian-api-client.ts
+export function createAtlassianClient(
+  token: string,
+  authType?: 'oauth' | 'pat',
+  siteName?: string,
+): AtlassianClient {
+  if (authType === 'pat') {
+    return createAtlassianClientWithPAT(token, siteName);
+  }
+  // existing OAuth logic...
+}
+```
+
+Every call site changes from:
+```typescript
+const client = createAtlassianClient(authInfo.atlassian.access_token);
+```
+to:
+```typescript
+const client = createAtlassianClient(
+  authInfo.atlassian.access_token,
+  authInfo.atlassian.authType,
+  siteName,
+);
+```
+
+**Option B: New `createAtlassianClientFromAuth()` helper, call sites pass `ProviderAuthInfo`**
+
+Add a new function that accepts `ProviderAuthInfo` directly and routes internally:
+
+```typescript
+// atlassian-api-client.ts
+export function createAtlassianClientFromAuth(
+  atlassian: ProviderAuthInfo,
+  siteName?: string,
+): AtlassianClient {
+  if (atlassian.authType === 'pat') {
+    return createAtlassianClientWithPAT(atlassian.access_token, siteName);
+  }
+  return createAtlassianClient(atlassian.access_token);
+}
+```
+
+Every call site changes from:
+```typescript
+const client = createAtlassianClient(authInfo.atlassian.access_token);
+```
+to:
+```typescript
+const client = createAtlassianClientFromAuth(authInfo.atlassian, siteName);
+```
+
+**Comparison:**
+
+| | Option A | Option B |
+|---|---|---|
+| Call site diff | Pass 2 extra args | Pass whole `ProviderAuthInfo` object |
+| Routing logic | Duplicated at call site | Centralized in one helper |
+| Existing `createAtlassianClient` | Modified (signature change) | Unchanged |
+| Call sites that skip `authType` | Could forget to pass it | N/A — `authType` is on the object |
+
+Option B chosen: routing logic lives in one place, call sites can't accidentally omit `authType`, and the existing `createAtlassianClient` is left unchanged (REST API and other non-auth-context callers are unaffected).

--- a/test/e2e/mcp-pat-auth.test.ts
+++ b/test/e2e/mcp-pat-auth.test.ts
@@ -76,6 +76,7 @@ describe('MCP PAT Header Authentication', () => {
     serverUrl = await startTestServer({
       testMode: false,
       logLevel: 'error',
+      port: 3000,
     });
   }, 30000);
 
@@ -128,11 +129,12 @@ describe('MCP PAT Header Authentication', () => {
     });
 
     // Should get a successful response with issue data
-    expect(result.content).toBeDefined();
-    expect(Array.isArray(result.content)).toBe(true);
-    expect(result.content.length).toBeGreaterThan(0);
+    const content = result.content as any[];
+    expect(content).toBeDefined();
+    expect(Array.isArray(content)).toBe(true);
+    expect(content.length).toBeGreaterThan(0);
 
-    const textContent = (result.content as any[]).find(c => c.type === 'text');
+    const textContent = content.find(c => c.type === 'text');
     expect(textContent).toBeDefined();
 
     // Should contain the issue key in the response

--- a/test/e2e/mcp-pat-auth.test.ts
+++ b/test/e2e/mcp-pat-auth.test.ts
@@ -1,0 +1,277 @@
+/**
+ * MCP PAT Header Authentication E2E Test
+ *
+ * Validates that MCP clients can authenticate using Personal Access Token headers
+ * (X-Atlassian-Token, X-Figma-Token) instead of the OAuth PKCE flow.
+ *
+ * Tests:
+ * 1. Session initialization with PAT headers (no JWT)
+ * 2. Calling an Atlassian tool (atlassian-get-issue) with PAT auth
+ * 3. Calling a Figma tool (figma-get-user) with PAT auth
+ * 4. Verifying subsequent requests on the same session work
+ * 5. Verifying invalid PATs return tool errors (not OAuth re-auth 401s)
+ *
+ * Requirements:
+ * - ATLASSIAN_TEST_PAT: Base64-encoded email:api_token for Jira
+ * - FIGMA_TEST_PAT: Figma personal access token
+ * - JIRA_TEST_ISSUE_KEY: A known Jira issue key (e.g., "PLAY-29")
+ *
+ * Run: npm run test:e2e -- --testPathPattern=mcp-pat-auth
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from '@jest/globals';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { startTestServer, stopTestServer } from '../../specs/shared/helpers/test-server.js';
+
+// Test configuration from environment
+const ATLASSIAN_PAT = process.env.ATLASSIAN_TEST_PAT?.replace(/^"|"$/g, '');
+const FIGMA_PAT = process.env.FIGMA_TEST_PAT?.replace(/^"|"$/g, '');
+const JIRA_ISSUE_KEY = process.env.JIRA_TEST_ISSUE_KEY || 'PLAY-29';
+const JIRA_SITE_NAME = 'bitovi';
+
+const shouldSkip = !ATLASSIAN_PAT || !FIGMA_PAT;
+
+if (shouldSkip) {
+  console.warn('⚠️  Skipping MCP PAT auth E2E tests — missing required environment variables:');
+  if (!ATLASSIAN_PAT) console.warn('  - ATLASSIAN_TEST_PAT (base64(email:token))');
+  if (!FIGMA_PAT) console.warn('  - FIGMA_TEST_PAT (figd_...)');
+}
+
+/**
+ * Create an MCP transport that uses PAT headers instead of JWT Bearer auth
+ */
+function createPatTransport(
+  serverUrl: string,
+  headers: Record<string, string>,
+  sessionId?: string,
+): StreamableHTTPClientTransport {
+  const opts: any = {
+    requestInit: {
+      headers,
+    },
+  };
+  if (sessionId) {
+    opts.sessionId = sessionId;
+  }
+  return new StreamableHTTPClientTransport(new URL('/mcp', serverUrl), opts);
+}
+
+function createClient(name: string = 'pat-auth-test-client'): Client {
+  return new Client(
+    { name, version: '1.0.0' },
+    { capabilities: {} },
+  );
+}
+
+describe('MCP PAT Header Authentication', () => {
+  let serverUrl: string;
+
+  beforeAll(async () => {
+    if (shouldSkip) return;
+
+    // Don't use mock Atlassian — we're hitting real APIs with PATs
+    delete process.env.TEST_USE_MOCK_ATLASSIAN;
+
+    serverUrl = await startTestServer({
+      testMode: false,
+      logLevel: 'error',
+    });
+  }, 30000);
+
+  afterAll(async () => {
+    if (shouldSkip) return;
+    await stopTestServer();
+  }, 15000);
+
+  test('should initialize MCP session with PAT headers', async () => {
+    if (shouldSkip) return;
+
+    const transport = createPatTransport(serverUrl, {
+      'X-Atlassian-Token': ATLASSIAN_PAT!,
+      'X-Figma-Token': FIGMA_PAT!,
+    });
+    const client = createClient();
+
+    await client.connect(transport);
+
+    // Verify we got a session — listTools should work
+    const { tools } = await client.listTools();
+    expect(tools.length).toBeGreaterThan(0);
+
+    // Should have both Atlassian and Figma tools available
+    const toolNames = tools.map(t => t.name);
+    expect(toolNames).toContain('atlassian-get-issue');
+    expect(toolNames).toContain('figma-get-user');
+
+    console.log(`  ✅ Session initialized with ${tools.length} tools available`);
+
+    await client.close();
+  }, 30000);
+
+  test('should fetch Jira issue using Atlassian PAT', async () => {
+    if (shouldSkip) return;
+
+    const transport = createPatTransport(serverUrl, {
+      'X-Atlassian-Token': ATLASSIAN_PAT!,
+      'X-Figma-Token': FIGMA_PAT!,
+    });
+    const client = createClient();
+    await client.connect(transport);
+
+    const result = await client.callTool({
+      name: 'atlassian-get-issue',
+      arguments: {
+        issueKey: JIRA_ISSUE_KEY,
+        siteName: JIRA_SITE_NAME,
+      },
+    });
+
+    // Should get a successful response with issue data
+    expect(result.content).toBeDefined();
+    expect(Array.isArray(result.content)).toBe(true);
+    expect(result.content.length).toBeGreaterThan(0);
+
+    const textContent = (result.content as any[]).find(c => c.type === 'text');
+    expect(textContent).toBeDefined();
+
+    // Should contain the issue key in the response
+    expect(textContent.text).toContain(JIRA_ISSUE_KEY);
+    // Should NOT contain error messages
+    expect(textContent.text).not.toContain('Error: No Atlassian access token');
+
+    console.log(`  ✅ Fetched ${JIRA_ISSUE_KEY} via Atlassian PAT`);
+
+    await client.close();
+  }, 30000);
+
+  test('should fetch Figma user info using Figma PAT', async () => {
+    if (shouldSkip) return;
+
+    const transport = createPatTransport(serverUrl, {
+      'X-Atlassian-Token': ATLASSIAN_PAT!,
+      'X-Figma-Token': FIGMA_PAT!,
+    });
+    const client = createClient();
+    await client.connect(transport);
+
+    const result = await client.callTool({
+      name: 'figma-get-user',
+      arguments: {},
+    });
+
+    expect(result.content).toBeDefined();
+    expect(Array.isArray(result.content)).toBe(true);
+
+    const textContent = (result.content as any[]).find(c => c.type === 'text');
+    expect(textContent).toBeDefined();
+
+    // Should contain user info (email or handle), not an error
+    expect(textContent.text).not.toContain('Error: No Figma access token');
+    expect(textContent.text).not.toContain('401');
+
+    console.log(`  ✅ Fetched Figma user info via PAT`);
+
+    await client.close();
+  }, 30000);
+
+  test('should work with only Atlassian PAT (no Figma)', async () => {
+    if (shouldSkip) return;
+
+    const transport = createPatTransport(serverUrl, {
+      'X-Atlassian-Token': ATLASSIAN_PAT!,
+    });
+    const client = createClient();
+    await client.connect(transport);
+
+    // Atlassian tool should work
+    const result = await client.callTool({
+      name: 'atlassian-get-issue',
+      arguments: {
+        issueKey: JIRA_ISSUE_KEY,
+        siteName: JIRA_SITE_NAME,
+      },
+    });
+
+    const textContent = (result.content as any[]).find(c => c.type === 'text');
+    expect(textContent.text).toContain(JIRA_ISSUE_KEY);
+
+    // Figma tool should not be available (not registered without Figma token)
+    // or should return a clear error (not crash or trigger OAuth)
+    try {
+      const figmaResult = await client.callTool({
+        name: 'figma-get-user',
+        arguments: {},
+      });
+      // If the call succeeds, check for an error message
+      const figmaText = (figmaResult.content as any[]).find(c => c.type === 'text');
+      expect(figmaText.text).toMatch(/No Figma access token|not found/i);
+    } catch (err: any) {
+      // Tool not found error is also acceptable — means Figma tools weren't registered
+      expect(err.message || String(err)).toContain('not found');
+    }
+
+    console.log(`  ✅ Single-provider PAT works correctly`);
+
+    await client.close();
+  }, 30000);
+
+  test('should return tool error for invalid Atlassian PAT (not OAuth re-auth)', async () => {
+    if (shouldSkip) return;
+
+    const transport = createPatTransport(serverUrl, {
+      'X-Atlassian-Token': 'aW52YWxpZEBleGFtcGxlLmNvbTppbnZhbGlkLXRva2Vu', // base64("invalid@example.com:invalid-token")
+      'X-Figma-Token': FIGMA_PAT!,
+    });
+    const client = createClient();
+    await client.connect(transport);
+
+    // This should NOT throw an error that triggers OAuth re-auth.
+    // It should return a tool error response instead.
+    const result = await client.callTool({
+      name: 'atlassian-get-issue',
+      arguments: {
+        issueKey: JIRA_ISSUE_KEY,
+        siteName: JIRA_SITE_NAME,
+      },
+    });
+
+    // The call should complete (not throw) — we get a tool response with an error message
+    expect(result.content).toBeDefined();
+
+    console.log(`  ✅ Invalid PAT returns tool error, not OAuth re-auth`);
+
+    await client.close();
+  }, 30000);
+
+  test('should handle multiple tool calls on same PAT session', async () => {
+    if (shouldSkip) return;
+
+    const transport = createPatTransport(serverUrl, {
+      'X-Atlassian-Token': ATLASSIAN_PAT!,
+      'X-Figma-Token': FIGMA_PAT!,
+    });
+    const client = createClient();
+    await client.connect(transport);
+
+    // First call
+    const result1 = await client.callTool({
+      name: 'atlassian-get-issue',
+      arguments: { issueKey: JIRA_ISSUE_KEY, siteName: JIRA_SITE_NAME },
+    });
+    const text1 = (result1.content as any[]).find(c => c.type === 'text');
+    expect(text1.text).toContain(JIRA_ISSUE_KEY);
+
+    // Second call on the same session
+    const result2 = await client.callTool({
+      name: 'figma-get-user',
+      arguments: {},
+    });
+    const text2 = (result2.content as any[]).find(c => c.type === 'text');
+    expect(text2.text).not.toContain('Error: No Figma access token');
+
+    console.log(`  ✅ Multiple tool calls on same PAT session work`);
+
+    await client.close();
+  }, 30000);
+});


### PR DESCRIPTION
- Add X-Atlassian-Token, X-Figma-Token, X-Google-Token header extraction
- Wire PAT headers as third auth fallback in validateAuthFromRequest
- Add createAtlassianClientFromAuth() for auto-routing OAuth vs PAT
- Update all 15 MCP tool call sites to use createAtlassianClientFromAuth
- Skip OAuth re-auth (InvalidTokenError) for PAT sessions
- Add e2e test suite (6 tests) for PAT auth flow
- Add docs/mcp-pat-headers-setup.md with MCP client config examples
- Update server/readme.md and copilot-instructions.md