### PR TITLE
fix: add PAT header fallback to GET /mcp SSE handler

### DIFF
--- a/server/mcp-service.ts
+++ b/server/mcp-service.ts
@@ -219,6 +219,18 @@ export async function handleSessionRequest(req: Request, res: Response): Promise
       ({ authInfo, errored } = await getAuthInfoFromQueryToken(req, res));
     }
     if (errored) { return; }
+
+    // Fall back to PAT headers
+    if (!authInfo) {
+      authInfo = getAuthInfoFromPatHeaders(req);
+      if (authInfo) {
+        console.log('🔑 Using PAT header authentication for GET request', {
+          providers: Object.keys(authInfo).filter(k => 
+            ['atlassian', 'figma', 'google'].includes(k) && authInfo![k as keyof AuthContext]
+          ),
+        });
+      }
+    }
     
     if (!authInfo) {
       // For GET requests, send 401 with invalid_token to trigger re-auth

--- a/test/e2e/mcp-pat-auth.test.ts
+++ b/test/e2e/mcp-pat-auth.test.ts
@@ -276,4 +276,57 @@ describe('MCP PAT Header Authentication', () => {
 
     await client.close();
   }, 30000);
+
+  test('should authenticate GET /mcp SSE stream with PAT headers', async () => {
+    if (shouldSkip) return;
+
+    // First, establish a session via POST (initialize)
+    const initRes = await fetch(`${serverUrl}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+        'X-Atlassian-Token': ATLASSIAN_PAT!,
+        'X-Figma-Token': FIGMA_PAT!,
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: 'sse-test-client', version: '1.0' },
+        },
+        id: 1,
+      }),
+    });
+
+    expect(initRes.status).toBe(200);
+    const sessionId = initRes.headers.get('mcp-session-id');
+    expect(sessionId).toBeTruthy();
+
+    // Now open a GET SSE stream with PAT headers — this is what VS Code does
+    // and what was failing before the fix (returned 401, triggered PKCE)
+    const abortController = new AbortController();
+    const sseRes = await fetch(`${serverUrl}/mcp`, {
+      method: 'GET',
+      headers: {
+        'Accept': 'text/event-stream',
+        'X-Atlassian-Token': ATLASSIAN_PAT!,
+        'X-Figma-Token': FIGMA_PAT!,
+        'mcp-session-id': sessionId!,
+      },
+      signal: abortController.signal,
+    });
+
+    // Should NOT be 401 — that's the bug we're guarding against
+    expect(sseRes.status).not.toBe(401);
+    // Should be 200 (SSE stream opened) or 204 (no content yet)
+    expect([200, 204]).toContain(sseRes.status);
+
+    // Clean up the SSE stream to avoid open handle warnings
+    abortController.abort();
+
+    console.log(`  ✅ GET /mcp SSE stream authenticated with PAT headers (status: ${sseRes.status})`);
+  }, 30000);
 });


### PR DESCRIPTION
The GET handler for SSE streams had its own auth check that only tried Bearer token and query param, missing the PAT header fallback. This caused VS Code to receive a 401 on the SSE stream and trigger PKCE.

Also adds an e2e test that explicitly validates GET /mcp with PAT headers to prevent regression.