### PR TITLE
feat: add figma-batch-cache and figma-frame-data tools (spec 069)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ Supported tools at the `https://cascade.bitovi.com/mcp` endpoint:
 **Figma Tools**:
 - **[`figma-get-user`](./server/providers/figma/tools/figma-get-user.md)** - Get information about the authenticated Figma user (test tool for OAuth validation)
 - **[`figma-review-design`](./server/providers/figma/tools/figma-review-design/figma-review-design.ts)** - Analyze Figma screen designs and post clarifying questions as comments on relevant frames
-- **[`figma-batch-load`](./server/providers/figma/tools/figma-batch-load/figma-batch-load.ts)** - Batch-fetch Figma data for multiple URLs; returns a zip download containing per-frame images, structure XML, comments, notes, and analysis prompts
-- **[`figma-ask-scope-questions-for-page`](./server/providers/figma/tools/figma-ask-scope-questions-for-page/figma-ask-scope-questions-for-page.ts)** - Analyze a Figma page and generate design scope questions with frame data and embedded analysis prompts
+- **[`figma-batch-zip`](./server/providers/figma/tools/figma-batch-load/figma-batch-load.ts)** - Batch-fetch Figma data for multiple URLs; returns a zip download containing per-frame images, structure XML, comments, notes, and analysis prompts (was `figma-batch-load`)
+- **[`figma-batch-cache`](./server/providers/figma/tools/figma-batch-cache/figma-batch-cache.ts)** - Batch-fetch Figma data into server-side cache; returns a batchToken for retrieval via `figma-frame-data` (cloud environments)
+- **[`figma-frame-data`](./server/providers/figma/tools/figma-frame-data/figma-frame-data.ts)** - Retrieve a single frame's data (image, context, XML) from batch cache or live Figma
+- **[`figma-ask-scope-questions-for-page`](./server/providers/figma/tools/figma-ask-scope-questions-for-page/figma-ask-scope-questions-for-page.ts)** - [DEPRECATED] Analyze a Figma page and generate design scope questions with frame data and embedded analysis prompts
 - **[`figma-post-comment`](./server/providers/figma/tools/figma-post-comment.ts)** - Post a comment to a Figma file, optionally pinned to a specific frame node
 - **[`figma-get-comments`](./server/providers/figma/tools/figma-get-comments.ts)** - Read existing comments from a Figma file, grouped into threads
 - **[`figma-get-image-download`](./server/providers/figma/tools/figma-get-image-download.md)** - Download images from Figma design URLs (returns base64-encoded image and metadata)

--- a/plugins/cascade-mcp/README.md
+++ b/plugins/cascade-mcp/README.md
@@ -77,7 +77,7 @@ https://github.com/bitovi/cascade-mcp
 Skills are SKILL.md instruction files that guide the AI agent through multi-step workflows. The agent:
 
 1. Reads the SKILL.md for step-by-step instructions
-2. Calls MCP tools (e.g., `figma-batch-load`, `atlassian-get-issue`) for data and side-effects
+2. Calls MCP tools (e.g., `figma-batch-zip`, `atlassian-get-issue`) for data and side-effects
 3. Uses its own LLM for generation (no sampling dependency)
 4. Saves intermediate results to `.temp/cascade/` for caching
 
@@ -85,7 +85,9 @@ Skills are SKILL.md instruction files that guide the AI agent through multi-step
 
 | Tool | Purpose |
 |------|---------|
-| `figma-batch-load` | Batch-fetch Figma frames → zip with images, structure XML, prompts |
+| `figma-batch-zip` | Batch-fetch Figma frames → zip with images, structure XML, prompts |
+| `figma-batch-cache` | Batch-fetch Figma frames into server-side cache (cloud environments) |
+| `figma-frame-data` | Retrieve one frame's data from cache or live Figma |
 | `figma-post-comment` | Post a comment to a Figma file (optionally pinned to a node) |
 | `figma-get-comments` | Read comment threads from a Figma file |
 | `atlassian-add-comment` | Post a markdown comment to a Jira issue |

--- a/plugins/cascade-mcp/skills/cascade-analyze-figma-frame-mcp/SKILL.md
+++ b/plugins/cascade-mcp/skills/cascade-analyze-figma-frame-mcp/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: cascade-analyze-figma-frame-mcp
+description: "Sub-skill: Analyze a single Figma design frame via the figma-frame-data MCP tool. Use this variant when local files are NOT available (e.g., GitHub cloud Copilot where curl is blocked). Calls figma-frame-data with a batchToken to retrieve image, structure, and context via MCP, then analyzes and returns the analysis as text. No filesystem reads needed — pure MCP."
+---
+
+# Analyze Figma Frame (MCP)
+
+Analyze a single Figma design frame by retrieving its data via the `figma-frame-data` MCP tool. This skill is designed for environments where local files are NOT available (e.g., GitHub cloud Copilot where `curl` cannot download zip files).
+
+Use `cascade-analyze-figma-frame` (the filesystem variant) when local files ARE available — it's faster and avoids MCP round-trips.
+
+## When to Use
+
+This is a **sub-skill** called as a subagent by parent skills during parallel frame analysis when the **cache path** is being used (i.e., `figma-batch-cache` was called instead of `figma-batch-zip`).
+
+The parent skill passes:
+- The frame's **Figma URL** (with `node-id`)
+- The **batchToken** from `figma-batch-cache`
+
+## Prerequisites
+
+- Cascade MCP server connected (tools available)
+- A valid `batchToken` from a prior `figma-batch-cache` call
+- The frame's Figma URL (must contain `node-id`)
+
+## Procedure
+
+### 1. Retrieve frame data via MCP
+
+Call the MCP tool `figma-frame-data` with:
+- `url`: The Figma URL for this frame (passed by parent)
+- `batchToken`: The batch token (passed by parent)
+- `includeStructure`: `true`
+
+The tool returns multiple content blocks:
+- **Image** — The frame screenshot (use as vision input for analysis)
+- **Context markdown** — Designer annotations, comments, connections to other frames
+- **Structure XML** — Semantic XML component tree
+- **Metadata JSON** — Frame ID, name, file key
+
+### 2. Analyze the frame
+
+Using the image, context, and structure from the MCP response, perform the analysis. Key analysis areas:
+
+#### Page Structure
+- Header, navigation, layout regions
+- Visual hierarchy and content flow
+
+#### Layout Structure Analysis
+- Grid dimensions (count rows, columns systematically)
+- Element mapping within the grid
+- Spacing and alignment patterns
+
+#### Primary UI Elements
+- Buttons, forms, tabs, dropdowns — with **exact labels** from the design
+- Visual states: active, hover, disabled, selected, empty
+- Component names from the structure XML
+
+#### Data Display
+- Tables, lists, cards, charts
+- Visual indicators (badges, status icons, progress bars)
+- Data formatting patterns
+
+#### Interactive Behaviors
+- Clickable elements and expected actions
+- State changes (toggle, expand/collapse, modal triggers)
+- Navigation flows (where does clicking go?)
+
+#### Scope Assessment
+Categorize observed features using scope markers:
+- **☐ In-Scope** — New work to implement
+- **✅ Already Done** — Existing functionality visible in the design
+- **❌ Out-of-Scope** — Features visible but excluded (check context for scope notes)
+- **⏬ Low Priority** — Implement later
+- **❓ Questions** — Ambiguous requirements that need clarification
+
+**Important scope rules:**
+- If context contains scope-limiting notes (e.g., "out of scope", "phase 2"), respect them
+- If a feature is visible in the design but context says it's out-of-scope, mark it ❌
+- Cross-reference with the structure XML for hidden or conditional elements
+
+#### Technical Considerations
+- Responsive/breakpoint implications
+- Accessibility requirements (ARIA, keyboard nav, contrast)
+- Loading states, error states, empty states
+- Performance considerations (large lists, real-time updates)
+
+### 3. Return analysis
+
+Return your complete analysis as text to the parent agent. **Do NOT write files** — the parent agent will handle collecting analyses from all frame subagents.
+
+## Output Format
+
+```markdown
+# Frame Analysis: {Frame Name}
+
+## Page Structure
+{header, navigation, layout description}
+
+## Layout Structure Analysis
+{grid dimensions, element mapping}
+
+## Primary UI Elements
+{buttons, forms, tabs with exact labels}
+
+## Data Display
+{tables, lists, visual indicators}
+
+## Interactive Behaviors
+{clickable elements, state changes}
+
+## Scope Assessment
+- ☐ {in-scope feature}: {description}
+- ✅ {already done feature}: {description}
+- ❌ {out-of-scope feature}: {description}
+- ❓ {question about ambiguous feature}
+
+## Technical Considerations
+{responsive, accessibility, loading states}
+```

--- a/plugins/cascade-mcp/skills/cascade-load-linked-resource-content/SKILL.md
+++ b/plugins/cascade-mcp/skills/cascade-load-linked-resource-content/SKILL.md
@@ -49,7 +49,7 @@ This returns **markdown with YAML frontmatter** containing:
 - For Jira: `relationship` on each link (parent, blocks, relates-to, etc.)
 - For Jira: `hasMoreComments` / `commentsStartAt` for comment pagination
 
-**Figma URLs**: If a Figma URL is passed, the tool returns a message to use `figma-batch-load` instead. Figma URLs should NOT be loaded by this skill.
+**Figma URLs**: If a Figma URL is passed, the tool returns a message to use `figma-batch-zip` instead. Figma URLs should NOT be loaded by this skill.
 
 ### 3. Save fetched content
 
@@ -94,7 +94,7 @@ Mark loaded URLs as `[x]` and append any newly discovered URLs as `[ ]`:
 - https://www.figma.com/design/abc123/Designs?node-id=0-1
 ```
 
-**Important**: Figma URLs should be listed in a separate "Figma" section — they are NOT loaded by this skill. The parent skill handles Figma loading via `figma-batch-load`.
+**Important**: Figma URLs should be listed in a separate "Figma" section — they are NOT loaded by this skill. The parent skill handles Figma loading via `figma-batch-zip` (or `figma-batch-cache` in cloud environments).
 
 ### 6. Return to parent skill
 
@@ -107,7 +107,7 @@ The parent skill decides whether to call `load-linked-resource-content` again (i
 
 ## Important Notes
 
-- **Do NOT load Figma URLs** — they require batch loading via `figma-batch-load` + `curl`/`unzip`, which the parent skill handles
+- **Do NOT load Figma URLs** — they require batch loading via `figma-batch-zip` + `curl`/`unzip` (or `figma-batch-cache` in cloud environments), which the parent skill handles
 - **Do NOT analyze or summarize content** — that's the `summarize-document-content` sub-skill's job
 - **Deduplicate URLs** — don't add a URL to `to-load.md` if it's already there (loaded or unloaded)
 - **Handle errors gracefully** — if a tool call fails, mark the URL with `[!]` in the manifest and continue with other URLs

--- a/plugins/cascade-mcp/skills/generate-behavior-questions/SKILL.md
+++ b/plugins/cascade-mcp/skills/generate-behavior-questions/SKILL.md
@@ -47,14 +47,13 @@ For each non-Figma URL in `to-load.md` (prioritize `parent` and `blocks` relatio
 
 For each Figma URL collected:
 
-1. Call MCP tool `figma-batch-load` with the Figma file URL
-   - This returns a download URL for a zip file
-2. Download and extract the zip:
+1. Call MCP tool `figma-batch-zip` with the Figma file URL
+   - This returns a `downloadUrl` for a zip file and a `manifest`
+2. Try to download and extract the zip:
    ```
-   curl -o .temp/cascade/figma/{fileKey}/batch.zip "{downloadUrl}"
-   cd .temp/cascade/figma/{fileKey} && unzip -o batch.zip
+   curl -sL "{downloadUrl}" -o /tmp/cascade-figma.zip && unzip -qo /tmp/cascade-figma.zip -d .temp/cascade/figma/ && rm /tmp/cascade-figma.zip
    ```
-3. The extracted zip contains:
+3. **If curl succeeds** (exit code 0), the extracted data is at:
    ```
    .temp/cascade/figma/{fileKey}/
    ├── manifest.json              ← frame list with metadata
@@ -67,16 +66,34 @@ For each Figma URL collected:
        │   └── context.md          ← annotations/connections
        └── ...
    ```
+   → Proceed to Phase 4 (filesystem path).
+
+4. **If curl fails** (e.g., DNS resolution blocked in cloud environments):
+   - Call MCP tool `figma-batch-cache` with the same Figma URLs
+   - Note the `batchToken` and `manifest` from the response
+   → Proceed to Phase 4 (MCP path).
 
 ### Phase 4: Parallel Frame Analysis
 
+**Choose the matching path based on Phase 3 outcome:**
+
+#### Path A: Local files available (zip succeeded)
+
 For each frame listed in `manifest.json`:
 
-1. Launch a **subagent** using the `analyze-figma-frame` sub-skill
+1. Launch a **subagent** using the `cascade-analyze-figma-frame` sub-skill
 2. Pass only the **frame directory path** (e.g., `.temp/cascade/figma/{fileKey}/frames/{dirName}/`) — the subagent reads the files itself
 3. Subagents write `analysis.md` to their frame directory
 
 **Do NOT read context.md, structure.xml, or image.png yourself.** The subagent handles all file reading. You only pass the path.
+
+#### Path B: MCP cache (curl failed, using batch cache)
+
+For each frame in the `manifest` from `figma-batch-cache`:
+
+1. Launch a **subagent** using the `cascade-analyze-figma-frame-mcp` sub-skill
+2. Pass the frame's **Figma URL** and the **batchToken**
+3. The subagent calls `figma-frame-data(url, batchToken)` to retrieve its data via MCP, then returns its analysis as text
 
 **Run all frame subagents in parallel** — they are independent of each other.
 
@@ -151,6 +168,7 @@ After presenting, ask the user what they'd like to do next. Present these option
 ## Important Notes
 
 - **Subagent depth**: Frame analysis subagents are leaf tasks — they do NOT launch further subagents
-- **Cache efficiency**: If `.temp/cascade/figma/{fileKey}/` already has valid data, `figma-batch-load` may return cached data — don't re-download unnecessarily
+- **Cache efficiency**: If `.temp/cascade/figma/{fileKey}/` already has valid data, `figma-batch-zip` may return cached data — don't re-download unnecessarily
 - **Error resilience**: If a single frame analysis fails, report the error and continue with remaining frames
-- **Fresh comments**: To get the latest Figma comments (e.g., replies to previously posted questions), re-run `figma-batch-load` — it always fetches fresh annotation data per frame
+- **Fresh comments**: To get the latest Figma comments (e.g., replies to previously posted questions), re-run `figma-batch-zip` — it always fetches fresh annotation data per frame
+- **Two frame analysis paths**: Use `cascade-analyze-figma-frame` for local files (zip path) and `cascade-analyze-figma-frame-mcp` for MCP cache path. The parent skill chooses based on whether the zip download succeeded

--- a/plugins/cascade-mcp/skills/write-jira-story/SKILL.md
+++ b/plugins/cascade-mcp/skills/write-jira-story/SKILL.md
@@ -46,18 +46,31 @@ For each non-Figma URL in `to-load.md` (prioritize `parent` and `blocks` relatio
 
 For each Figma URL:
 
-1. Call `figma-batch-load` with the URL
-2. Download and extract:
+1. Call `figma-batch-zip` with the URL
+   - This returns a `downloadUrl` and `manifest`
+2. Try to download and extract:
    ```
-   curl -o .temp/cascade/figma/{fileKey}/batch.zip "{downloadUrl}"
-   cd .temp/cascade/figma/{fileKey} && unzip -o batch.zip
+   curl -sL "{downloadUrl}" -o /tmp/cascade-figma.zip && unzip -qo /tmp/cascade-figma.zip -d .temp/cascade/figma/ && rm /tmp/cascade-figma.zip
    ```
+3. **If curl fails** (e.g., DNS blocked in cloud environments):
+   - Call `figma-batch-cache` with the same Figma URLs
+   - Note the `batchToken` and `manifest` from the response
 
 ### Phase 4: Parallel Frame Analysis
 
-For each frame in `manifest.json`, launch a **subagent** with the `analyze-figma-frame` sub-skill.
+**Choose the matching path based on Phase 3 outcome:**
+
+#### Path A: Local files available (zip succeeded)
+
+For each frame in `manifest.json`, launch a **subagent** with the `cascade-analyze-figma-frame` sub-skill.
 
 **Pass only the frame directory path** (e.g., `.temp/cascade/figma/{fileKey}/frames/{dirName}/`). Do NOT read context.md, structure.xml, or image.png yourself — the subagent reads all files internally.
+
+#### Path B: MCP cache (curl failed, using batch cache)
+
+For each frame in the `manifest` from `figma-batch-cache`, launch a **subagent** with the `cascade-analyze-figma-frame-mcp` sub-skill.
+
+Pass the frame's **Figma URL** and the **batchToken**. The subagent calls `figma-frame-data(url, batchToken)` to retrieve data via MCP.
 
 Run all subagents in parallel.
 

--- a/plugins/cascade-mcp/skills/write-next-story-from-shell-story/SKILL.md
+++ b/plugins/cascade-mcp/skills/write-next-story-from-shell-story/SKILL.md
@@ -80,20 +80,33 @@ Record the story's:
 
 For each Figma URL in the target story's **SCREENS** list only (do NOT load all epic Figma files):
 
-1. Call MCP tool `figma-batch-load` with the Figma URL
-2. Download and extract:
+1. Call MCP tool `figma-batch-zip` with the Figma URL
+   - This returns a `downloadUrl` and `manifest`
+2. Try to download and extract:
    ```
-   curl -o .temp/cascade/figma/{fileKey}/batch.zip "{downloadUrl}"
-   cd .temp/cascade/figma/{fileKey} && unzip -o batch.zip
+   curl -sL "{downloadUrl}" -o /tmp/cascade-figma.zip && unzip -qo /tmp/cascade-figma.zip -d .temp/cascade/figma/ && rm /tmp/cascade-figma.zip
    ```
+3. **If curl fails** (e.g., DNS blocked in cloud environments):
+   - Call `figma-batch-cache` with the same Figma URLs
+   - Note the `batchToken` and `manifest` from the response
 
 If frames for these screens were already analyzed in a prior run (`.temp/cascade/figma/{fileKey}/frames/{dirName}/analysis.md` exists), skip re-downloading for that file.
 
 ### Phase 5: Parallel Frame Analysis
 
+**Choose the matching path based on Phase 4 outcome:**
+
+#### Path A: Local files available (zip succeeded)
+
 For each frame in the target story's screens, launch a **subagent** using the `cascade-analyze-figma-frame` sub-skill.
 
 **Pass only the frame directory path** (e.g., `.temp/cascade/figma/{fileKey}/frames/{dirName}/`). Do NOT read `context.md`, `structure.xml`, or `image.png` yourself — the subagent reads all files internally.
+
+#### Path B: MCP cache (curl failed, using batch cache)
+
+For each frame in the `manifest` from `figma-batch-cache`, launch a **subagent** using the `cascade-analyze-figma-frame-mcp` sub-skill.
+
+Pass the frame's **Figma URL** and the **batchToken**. The subagent calls `figma-frame-data(url, batchToken)` to retrieve data via MCP.
 
 Run all subagents in parallel. Wait for all to complete before proceeding.
 

--- a/plugins/cascade-mcp/skills/write-shell-stories/SKILL.md
+++ b/plugins/cascade-mcp/skills/write-shell-stories/SKILL.md
@@ -48,13 +48,13 @@ For each non-Figma URL in `to-load.md` (prioritize `parent` and `blocks` relatio
 
 For each Figma URL collected:
 
-1. Call MCP tool `figma-batch-load` with the Figma file URL
-2. Download and extract:
+1. Call MCP tool `figma-batch-zip` with the Figma file URL
+   - This returns a `downloadUrl` and `manifest`
+2. Try to download and extract:
    ```
-   curl -o .temp/cascade/figma/{fileKey}/batch.zip "{downloadUrl}"
-   cd .temp/cascade/figma/{fileKey} && unzip -o batch.zip
+   curl -sL "{downloadUrl}" -o /tmp/cascade-figma.zip && unzip -qo /tmp/cascade-figma.zip -d .temp/cascade/figma/ && rm /tmp/cascade-figma.zip
    ```
-3. The extracted zip contains:
+3. **If curl succeeds**, the extracted data is at:
    ```
    .temp/cascade/figma/{fileKey}/
    ├── manifest.json              ← frame list with metadata
@@ -67,12 +67,28 @@ For each Figma URL collected:
        │   └── context.md
        └── ...
    ```
+   → Proceed to Phase 4 (filesystem path).
+
+4. **If curl fails** (e.g., DNS blocked in cloud environments):
+   - Call `figma-batch-cache` with the same Figma URLs
+   - Note the `batchToken` and `manifest` from the response
+   → Proceed to Phase 4 (MCP path).
 
 ### Phase 4: Parallel Frame Analysis
+
+**Choose the matching path based on Phase 3 outcome:**
+
+#### Path A: Local files available (zip succeeded)
 
 For each frame listed in `manifest.json`, launch a **subagent** using the `cascade-analyze-figma-frame` sub-skill.
 
 **Pass only the frame directory path** (e.g., `.temp/cascade/figma/{fileKey}/frames/{dirName}/`). Do NOT read `context.md`, `structure.xml`, or `image.png` yourself — the subagent reads all files internally.
+
+#### Path B: MCP cache (curl failed, using batch cache)
+
+For each frame in the `manifest` from `figma-batch-cache`, launch a **subagent** using the `cascade-analyze-figma-frame-mcp` sub-skill.
+
+Pass the frame's **Figma URL** and the **batchToken**. The subagent calls `figma-frame-data(url, batchToken)` to retrieve data via MCP.
 
 Run all subagents in parallel. Wait for all to complete before proceeding.
 

--- a/server/api/download.ts
+++ b/server/api/download.ts
@@ -1,7 +1,7 @@
 /**
  * Download Endpoint
  * 
- * One-time zip download endpoint for figma-batch-load.
+ * One-time zip download endpoint for figma-batch-zip.
  * Not an MCP tool — a plain HTTP endpoint the agent hits via `curl`.
  * 
  * Security:

--- a/server/api/figma-batch-cache.ts
+++ b/server/api/figma-batch-cache.ts
@@ -1,8 +1,8 @@
 /**
- * REST API Handler for Figma Batch Load (figma-batch-zip)
+ * REST API Handler for Figma Batch Cache
  *
- * Batch-fetches Figma data for multiple URLs, builds a zip,
- * and returns a one-time download URL.
+ * Batch-fetches Figma data for multiple URLs into server-side cache.
+ * Returns a batchToken + manifest for subsequent figma-frame-data calls.
  *
  * Required Headers:
  *   X-Figma-Token: figd_...
@@ -17,10 +17,9 @@
 import type { Request, Response } from 'express';
 import { createFigmaClient } from '../providers/figma/figma-api-client.js';
 import { fetchBatchData } from '../providers/figma/tools/figma-batch-fetch.js';
-import { buildZip } from '../providers/figma/tools/figma-batch-load/zip-builder.js';
-import { registerDownload } from './download.js';
+import { createBatchCache } from '../providers/figma/batch-cache.js';
 
-export async function handleFigmaBatchZip(req: Request, res: Response): Promise<void> {
+export async function handleFigmaBatchCache(req: Request, res: Response): Promise<void> {
   try {
     const { requests, context } = req.body;
 
@@ -45,19 +44,19 @@ export async function handleFigmaBatchZip(req: Request, res: Response): Promise<
       return;
     }
 
-    const { zipPath, manifest } = await buildZip(fileDataResults);
-    const baseUrl = process.env.VITE_AUTH_SERVER_URL || `${req.protocol}://${req.get('host')}`;
-    const { token, expiresAt } = registerDownload(zipPath);
-    const downloadUrl = `${baseUrl}/dl/${token}`;
+    // Write to batch cache
+    const { batchToken, manifest } = await createBatchCache(fileDataResults);
 
     res.json({
       success: true,
-      downloadUrl,
-      expiresAt: expiresAt.toISOString(),
-      manifest,
+      batchToken,
+      manifest: {
+        files: manifest.files,
+        totalFrames: manifest.totalFrames,
+      },
     });
   } catch (error: any) {
-    console.error('REST API: figma-batch-zip failed:', error.message);
+    console.error('REST API: figma-batch-cache failed:', error.message);
     if (error.message?.includes('403') || error.message?.includes('unauthorized')) {
       res.status(401).json({ success: false, error: 'Figma authentication failed.' });
       return;

--- a/server/api/figma-frame-data.ts
+++ b/server/api/figma-frame-data.ts
@@ -1,0 +1,144 @@
+/**
+ * REST API Handler for Figma Frame Data
+ *
+ * Retrieves a single frame's image, context, and structure.
+ * Data only — no prompts or save instructions.
+ *
+ * Required Headers:
+ *   X-Figma-Token: figd_... (only needed if batchToken misses or is omitted)
+ *
+ * Request body:
+ * {
+ *   "url": "https://figma.com/design/FILE?node-id=1-2",
+ *   "batchToken": "optional-uuid",
+ *   "includeStructure": true,
+ *   "maxStructureSize": 50000
+ * }
+ */
+
+import type { Request, Response } from 'express';
+import { createFigmaClient } from '../providers/figma/figma-api-client.js';
+import {
+  parseFigmaUrl,
+  convertNodeIdToApiFormat,
+  fetchFigmaNodesBatch,
+  downloadFigmaImagesBatch,
+} from '../providers/figma/figma-helpers.js';
+import { generateSemanticXml } from '../providers/figma/semantic-xml-generator.js';
+import { getBatchCacheEntry, readBatchFrameData, type BatchCacheFrameData } from '../providers/figma/batch-cache.js';
+
+export async function handleFigmaFrameData(req: Request, res: Response): Promise<void> {
+  try {
+    const { url, batchToken, includeStructure = true, maxStructureSize = 50000 } = req.body;
+
+    if (!url || typeof url !== 'string') {
+      res.status(400).json({ success: false, error: 'url is required and must be a string' });
+      return;
+    }
+
+    // Parse URL
+    const parsed = parseFigmaUrl(url);
+    if (!parsed || !parsed.nodeId) {
+      res.status(400).json({ success: false, error: 'Invalid Figma URL — must contain a node-id parameter.' });
+      return;
+    }
+    const fileKey = parsed.fileKey;
+    const nodeId = convertNodeIdToApiFormat(parsed.nodeId);
+
+    // Try batch cache first
+    let frameData: BatchCacheFrameData | null = null;
+
+    if (batchToken) {
+      const cacheEntry = await getBatchCacheEntry(batchToken);
+      if (cacheEntry) {
+        frameData = await readBatchFrameData(batchToken, nodeId);
+      }
+    }
+
+    // Fall back to live fetch
+    if (!frameData) {
+      const figmaToken = req.headers['x-figma-token'] as string | undefined;
+      if (!figmaToken) {
+        res.status(401).json({ success: false, error: 'Missing X-Figma-Token header (required when cache miss).' });
+        return;
+      }
+
+      const figmaClient = createFigmaClient(figmaToken);
+
+      const [nodesDataMap, imageResult] = await Promise.all([
+        fetchFigmaNodesBatch(figmaClient, fileKey, [nodeId]),
+        downloadFigmaImagesBatch(figmaClient, fileKey, [nodeId], { format: 'png', scale: 1 }),
+      ]);
+
+      const nodeData = nodesDataMap.get(nodeId);
+      if (!nodeData) {
+        res.status(404).json({ success: false, error: `Frame node ${nodeId} not found in Figma file ${fileKey}` });
+        return;
+      }
+
+      const frameName = nodeData.name || nodeId;
+      let semanticXml = '';
+      try {
+        semanticXml = generateSemanticXml(nodeData);
+      } catch {
+        // Skip XML generation on failure
+      }
+
+      let imageBase64: string | undefined;
+      const imageData = imageResult.get(nodeId);
+      if (imageData) {
+        imageBase64 = imageData.base64Data;
+      }
+
+      frameData = {
+        nodeId,
+        name: frameName,
+        imageBase64,
+        imageMimeType: 'image/png',
+        contextMd: `# ${frameName} (Frame ${nodeId})\n\n_Standalone frame data._\n`,
+        semanticXml,
+      };
+    }
+
+    // Build response
+    const response: any = {
+      success: true,
+      frameData: {
+        frameId: frameData.nodeId,
+        frameName: frameData.name,
+        fileKey,
+        context: frameData.contextMd,
+        metadata: {
+          structureTruncated: frameData.semanticXml.length > maxStructureSize,
+          structureOriginalSize: frameData.semanticXml.length,
+        },
+      },
+    };
+
+    if (frameData.imageBase64) {
+      response.frameData.image = {
+        base64: frameData.imageBase64,
+        mimeType: frameData.imageMimeType || 'image/png',
+      };
+    }
+
+    if (includeStructure && frameData.semanticXml) {
+      let xml = frameData.semanticXml;
+      if (xml.length > maxStructureSize) {
+        const cutPoint = xml.lastIndexOf('</', maxStructureSize - 200);
+        const endTagEnd = cutPoint > 0 ? xml.indexOf('>', cutPoint) + 1 : maxStructureSize;
+        xml = xml.substring(0, endTagEnd > 0 ? endTagEnd : maxStructureSize);
+      }
+      response.frameData.structure = xml;
+    }
+
+    res.json(response);
+  } catch (error: any) {
+    console.error('REST API: figma-frame-data failed:', error.message);
+    if (error.message?.includes('403') || error.message?.includes('unauthorized')) {
+      res.status(401).json({ success: false, error: 'Figma authentication failed.' });
+      return;
+    }
+    res.status(500).json({ success: false, error: error.message });
+  }
+}

--- a/server/api/index.ts
+++ b/server/api/index.ts
@@ -13,7 +13,9 @@ import { handleIdentifyFeatures } from './identify-features.js';
 import { handleAnalyzeFeatureScope } from './analyze-feature-scope.js';
 import { handleFigmaReviewDesign } from './figma-review-design.js';
 import { handleReviewWorkItem } from './review-work-item.js';
-import { handleFigmaBatchLoad } from './figma-batch-load.js';
+import { handleFigmaBatchZip } from './figma-batch-load.js';
+import { handleFigmaBatchCache } from './figma-batch-cache.js';
+import { handleFigmaFrameData } from './figma-frame-data.js';
 import { handleFigmaPostComment } from './figma-post-comment.js';
 import { handleFigmaGetComments } from './figma-get-comments.js';
 import { handleAtlassianAddComment } from './atlassian-add-comment.js';
@@ -85,9 +87,21 @@ export function registerRestApiRoutes(app: Express): void {
   app.post('/api/review-work-item', (req, res) => handleReviewWorkItem(req, res));
   console.log('  ✓ POST /api/review-work-item');
   
-  // Batch load Figma frames to zip (spec 068 — plugin skills)
-  app.post('/api/figma-batch-load', (req, res) => handleFigmaBatchLoad(req, res));
-  console.log('  ✓ POST /api/figma-batch-load');
+  // Batch load Figma frames to zip (spec 068/069 — plugin skills)
+  app.post('/api/figma-batch-zip', (req, res) => handleFigmaBatchZip(req, res));
+  console.log('  ✓ POST /api/figma-batch-zip');
+  
+  // Legacy endpoint for backward compatibility
+  app.post('/api/figma-batch-load', (req, res) => handleFigmaBatchZip(req, res));
+  console.log('  ✓ POST /api/figma-batch-load (legacy → figma-batch-zip)');
+  
+  // Batch cache Figma frames for MCP retrieval (spec 069)
+  app.post('/api/figma-batch-cache', (req, res) => handleFigmaBatchCache(req, res));
+  console.log('  ✓ POST /api/figma-batch-cache');
+  
+  // Get single frame data (spec 069)
+  app.post('/api/figma-frame-data', (req, res) => handleFigmaFrameData(req, res));
+  console.log('  ✓ POST /api/figma-frame-data');
   
   // Post a comment to a Figma file
   app.post('/api/figma-post-comment', (req, res) => handleFigmaPostComment(req, res));

--- a/server/providers/combined/tools/extract-linked-resources/extract-linked-resources.ts
+++ b/server/providers/combined/tools/extract-linked-resources/extract-linked-resources.ts
@@ -90,7 +90,7 @@ export function registerExtractLinkedResourcesTool(mcp: McpServer): void {
           'URL to fetch. Supports: Jira issues (https://site.atlassian.net/browse/PROJ-123), ' +
           'Confluence pages (https://site.atlassian.net/wiki/...), ' +
           'Google Docs (https://docs.google.com/document/...). ' +
-          'For Figma URLs, returns a message to use figma-batch-load instead.'
+          'For Figma URLs, returns a message to use figma-batch-zip instead.'
         ),
         siteName: z.string().optional().describe(
           'Atlassian site name (e.g., "mycompany" from mycompany.atlassian.net). ' +

--- a/server/providers/combined/tools/extract-linked-resources/response-formatter.ts
+++ b/server/providers/combined/tools/extract-linked-resources/response-formatter.ts
@@ -194,7 +194,7 @@ export function formatFigmaResponse(data: FigmaResponseData): string {
     '---',
   ];
 
-  return `${frontmatter.join('\n')}\n\nThis is a Figma URL. Use the \`figma-batch-load\` tool to fetch Figma design data instead.`;
+  return `${frontmatter.join('\n')}\n\nThis is a Figma URL. Use the \`figma-batch-zip\` tool to fetch Figma design data instead.`;
 }
 
 export function formatUnsupportedResponse(url: string): string {

--- a/server/providers/figma/batch-cache.ts
+++ b/server/providers/figma/batch-cache.ts
@@ -1,0 +1,302 @@
+/**
+ * Figma Batch Cache
+ *
+ * Request-token-based server-side cache for batch Figma data (spec 069).
+ * Each batch gets an isolated directory keyed by a random UUID (batchToken).
+ * No cross-request sharing — separate users/sessions get separate caches.
+ *
+ * Cache characteristics:
+ * - 10-minute TTL (extended on read access)
+ * - Lazy cleanup on creation (same pattern as scope-cache.ts)
+ * - Directory: cache/figma-batch/{batchToken}/
+ * - Security: batchToken is a random UUID — no data leaks between sessions
+ */
+
+import * as crypto from 'crypto';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import { getBaseCacheDir } from '../combined/tools/writing-shell-stories/temp-directory-manager.js';
+import type { FetchedFileData, FetchedFrameData } from '../figma/tools/figma-batch-fetch.js';
+import { safeNodeId } from '../figma/tools/figma-batch-fetch.js';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Default TTL in milliseconds (10 minutes) */
+const DEFAULT_TTL_MS = 10 * 60 * 1000;
+
+/** TTL extension on successful read (5 minutes) */
+const TTL_EXTENSION_MS = 5 * 60 * 1000;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface BatchCacheMetadata {
+  batchToken: string;
+  createdAt: string;
+  expiresAt: string;
+  files: Array<{
+    fileKey: string;
+    fileName: string;
+    frames: Array<{
+      nodeId: string;
+      name: string;
+      dirName: string;
+      url: string;
+      order: number;
+      section?: string;
+      annotationCount: number;
+      width?: number;
+      height?: number;
+    }>;
+  }>;
+  totalFrames: number;
+}
+
+export interface BatchCacheFrameData {
+  nodeId: string;
+  name: string;
+  imageBase64?: string;
+  imageMimeType?: string;
+  contextMd: string;
+  semanticXml: string;
+}
+
+// ============================================================================
+// Path Helpers
+// ============================================================================
+
+function getBatchCacheBaseDir(): string {
+  return path.join(getBaseCacheDir(), 'figma-batch');
+}
+
+function getBatchDir(batchToken: string): string {
+  return path.join(getBatchCacheBaseDir(), batchToken);
+}
+
+function getMetadataPath(batchToken: string): string {
+  return path.join(getBatchDir(batchToken), '.cache-metadata.json');
+}
+
+function getFrameDir(batchToken: string, nodeId: string): string {
+  return path.join(getBatchDir(batchToken), 'frames', safeNodeId(nodeId));
+}
+
+// ============================================================================
+// Cache CRUD Operations
+// ============================================================================
+
+/**
+ * Create a batch cache entry with all file/frame data.
+ * Returns a batchToken and manifest for the caller to return to the agent.
+ */
+export async function createBatchCache(
+  fileDataResults: FetchedFileData[]
+): Promise<{ batchToken: string; manifest: BatchCacheMetadata }> {
+  const batchToken = crypto.randomUUID();
+  const batchDir = getBatchDir(batchToken);
+  const now = new Date();
+
+  // Create directory structure
+  await fs.mkdir(path.join(batchDir, 'frames'), { recursive: true });
+
+  // Build manifest and write frame data
+  const manifestFiles: BatchCacheMetadata['files'] = [];
+
+  for (const fileData of fileDataResults) {
+    const frameManifests: BatchCacheMetadata['files'][0]['frames'] = [];
+
+    for (const frame of fileData.frames) {
+      const frameDir = getFrameDir(batchToken, frame.nodeId);
+      await fs.mkdir(frameDir, { recursive: true });
+
+      // Write image
+      if (frame.imageBase64) {
+        const imageBuffer = Buffer.from(frame.imageBase64, 'base64');
+        await fs.writeFile(path.join(frameDir, 'image.png'), imageBuffer);
+      }
+
+      // Write context markdown
+      await fs.writeFile(path.join(frameDir, 'context.md'), frame.contextMd, 'utf-8');
+
+      // Write semantic XML
+      await fs.writeFile(path.join(frameDir, 'structure.xml'), frame.structureXml, 'utf-8');
+
+      frameManifests.push({
+        nodeId: frame.nodeId,
+        name: frame.name,
+        dirName: frame.dirName,
+        url: frame.url,
+        order: frame.order,
+        section: frame.section,
+        annotationCount: frame.annotationCount,
+        width: frame.width,
+        height: frame.height,
+      });
+    }
+
+    manifestFiles.push({
+      fileKey: fileData.fileKey,
+      fileName: fileData.fileName,
+      frames: frameManifests,
+    });
+  }
+
+  const totalFrames = manifestFiles.reduce((sum, f) => sum + f.frames.length, 0);
+
+  const manifest: BatchCacheMetadata = {
+    batchToken,
+    createdAt: now.toISOString(),
+    expiresAt: new Date(now.getTime() + DEFAULT_TTL_MS).toISOString(),
+    files: manifestFiles,
+    totalFrames,
+  };
+
+  // Write metadata
+  await fs.writeFile(getMetadataPath(batchToken), JSON.stringify(manifest, null, 2), 'utf-8');
+
+  // Trigger lazy cleanup of other expired entries
+  cleanupExpiredBatchCaches().catch(() => {
+    // Fire and forget — cleanup is best-effort
+  });
+
+  return { batchToken, manifest };
+}
+
+/**
+ * Validate and retrieve batch cache metadata.
+ * Returns null if cache is expired or doesn't exist.
+ * Extends TTL on successful read.
+ */
+export async function getBatchCacheEntry(
+  batchToken: string
+): Promise<BatchCacheMetadata | null> {
+  const metadataPath = getMetadataPath(batchToken);
+
+  try {
+    const raw = await fs.readFile(metadataPath, 'utf-8');
+    const metadata: BatchCacheMetadata = JSON.parse(raw);
+
+    // Validate batchToken matches
+    if (metadata.batchToken !== batchToken) {
+      return null;
+    }
+
+    // Check TTL
+    if (new Date(metadata.expiresAt).getTime() < Date.now()) {
+      // Expired — clean up
+      await fs.rm(getBatchDir(batchToken), { recursive: true, force: true }).catch(() => {});
+      return null;
+    }
+
+    // Extend TTL on access
+    metadata.expiresAt = new Date(
+      Math.max(new Date(metadata.expiresAt).getTime(), Date.now() + TTL_EXTENSION_MS)
+    ).toISOString();
+    await fs.writeFile(metadataPath, JSON.stringify(metadata, null, 2), 'utf-8').catch(() => {});
+
+    return metadata;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read cached frame data for a specific frame from a batch.
+ * Node IDs are unique within a batch — no file-key routing needed.
+ */
+export async function readBatchFrameData(
+  batchToken: string,
+  nodeId: string
+): Promise<BatchCacheFrameData | null> {
+  const frameDir = getFrameDir(batchToken, nodeId);
+
+  try {
+    await fs.access(frameDir);
+  } catch {
+    return null;
+  }
+
+  let imageBase64: string | undefined;
+  let imageMimeType: string | undefined;
+  try {
+    const imageBuffer = await fs.readFile(path.join(frameDir, 'image.png'));
+    imageBase64 = imageBuffer.toString('base64');
+    imageMimeType = 'image/png';
+  } catch {
+    // No image cached
+  }
+
+  let contextMd = '';
+  try {
+    contextMd = await fs.readFile(path.join(frameDir, 'context.md'), 'utf-8');
+  } catch {
+    // No context
+  }
+
+  let semanticXml = '';
+  try {
+    semanticXml = await fs.readFile(path.join(frameDir, 'structure.xml'), 'utf-8');
+  } catch {
+    // No structure
+  }
+
+  // Try to get the name from manifest metadata
+  let name = nodeId;
+  try {
+    const metaRaw = await fs.readFile(getMetadataPath(batchToken), 'utf-8');
+    const meta: BatchCacheMetadata = JSON.parse(metaRaw);
+    for (const file of meta.files) {
+      const frameInfo = file.frames.find(f => f.nodeId === nodeId);
+      if (frameInfo) {
+        name = frameInfo.name;
+        break;
+      }
+    }
+  } catch {
+    // Use nodeId as fallback name
+  }
+
+  return {
+    nodeId,
+    name,
+    imageBase64,
+    imageMimeType,
+    contextMd,
+    semanticXml,
+  };
+}
+
+/**
+ * Lazy cleanup: remove expired batch cache entries.
+ * Called when a new cache is created.
+ */
+async function cleanupExpiredBatchCaches(): Promise<void> {
+  const baseDir = getBatchCacheBaseDir();
+
+  try {
+    const entries = await fs.readdir(baseDir, { withFileTypes: true });
+    const now = Date.now();
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+
+      const metaPath = path.join(baseDir, entry.name, '.cache-metadata.json');
+      try {
+        const raw = await fs.readFile(metaPath, 'utf-8');
+        const metadata: BatchCacheMetadata = JSON.parse(raw);
+
+        if (new Date(metadata.expiresAt).getTime() < now) {
+          await fs.rm(path.join(baseDir, entry.name), { recursive: true, force: true });
+          console.log(`  Cleaned expired batch cache: ${entry.name}`);
+        }
+      } catch {
+        // Can't read metadata — skip
+      }
+    }
+  } catch {
+    // Base dir doesn't exist yet — nothing to clean
+  }
+}

--- a/server/providers/figma/tools/figma-ask-scope-questions-for-page/figma-ask-scope-questions-for-page.ts
+++ b/server/providers/figma/tools/figma-ask-scope-questions-for-page/figma-ask-scope-questions-for-page.ts
@@ -26,8 +26,9 @@ export function registerFigmaAskScopeQuestionsForPageTool(mcp: McpServer): void 
   mcp.registerTool(
     'figma-ask-scope-questions-for-page',
     {
-      title: 'Ask Scope Questions for Figma Page',
+      title: '[DEPRECATED] Ask Scope Questions for Figma Page',
       description:
+        '[DEPRECATED — use figma-batch-cache + figma-frame-data instead] ' +
         'Analyze a Figma page and generate design scope questions. ' +
         'Returns all frame data (images, annotations, semantic XML), embedded prompts for ' +
         'frame analysis, scope synthesis, and question generation, plus workflow instructions ' +
@@ -49,6 +50,7 @@ export function registerFigmaAskScopeQuestionsForPageTool(mcp: McpServer): void 
     },
     async ({ url, context }: ToolParams, mcpContext) => {
       console.log('figma-ask-scope-questions-for-page called');
+      console.log('  ⚠️ DEPRECATED: Use figma-batch-cache + figma-frame-data instead');
       console.log(`  URL: ${url}`);
       if (context) console.log(`  Context: ${context.substring(0, 100)}...`);
 

--- a/server/providers/figma/tools/figma-batch-cache/figma-batch-cache.ts
+++ b/server/providers/figma/tools/figma-batch-cache/figma-batch-cache.ts
@@ -1,0 +1,101 @@
+/**
+ * MCP Tool: figma-batch-cache
+ *
+ * Batch-fetches Figma data for multiple URLs into a server-side cache,
+ * returns a batchToken + manifest. Subagents then call figma-frame-data
+ * with the batchToken to retrieve individual frames.
+ *
+ * This is the fallback for environments where curl is blocked (e.g., GitHub
+ * cloud Copilot). All data transfer happens via MCP — no HTTP downloads.
+ *
+ * API budget per file: 1 Tier 3 (meta) + 1 Tier 1 (nodes) + 1 Tier 1 (images)
+ */
+
+import { z } from 'zod';
+import { getAuthInfoSafe } from '../../../../mcp-core/auth-helpers.js';
+import type { McpServer } from '../../../../mcp-core/mcp-types.js';
+import { createFigmaClient } from '../../figma-api-client.js';
+import { fetchBatchData } from '../figma-batch-fetch.js';
+import { createBatchCache } from '../../batch-cache.js';
+
+interface FigmaBatchCacheParams {
+  requests: Array<{ url: string; label?: string }>;
+  context?: string;
+}
+
+/**
+ * Register the figma-batch-cache tool with the MCP server
+ */
+export function registerFigmaBatchCacheTool(mcp: McpServer): void {
+  mcp.registerTool(
+    'figma-batch-cache',
+    {
+      title: 'Batch Cache Figma Data',
+      description:
+        'Batch-fetch Figma data for multiple URLs into server-side cache. Returns a batchToken + manifest. ' +
+        'Use figma-frame-data(url, batchToken) to retrieve individual frames from cache. ' +
+        'This is the alternative to figma-batch-zip for environments where curl/HTTP downloads are blocked ' +
+        '(e.g., GitHub cloud Copilot). All data stays server-side until retrieved via MCP.',
+      inputSchema: {
+        requests: z.array(z.object({
+          url: z.string().describe('Figma URL — page-level or frame-level'),
+          label: z.string().optional().describe('Human label (e.g., "Login Screen")'),
+        })).min(1).describe('Figma URLs to load. Can span multiple files. Deduplicates by file.'),
+        context: z.string().optional()
+          .describe('Feature context for annotation association'),
+      },
+    },
+    async ({ requests, context }: FigmaBatchCacheParams, mcpContext) => {
+      console.log('figma-batch-cache called');
+      console.log('  Requests:', requests.length);
+
+      try {
+        const authInfo = getAuthInfoSafe(mcpContext, 'figma-batch-cache');
+        const figmaToken = authInfo?.figma?.access_token;
+
+        if (!figmaToken) {
+          return {
+            content: [{ type: 'text' as const, text: 'Error: No Figma access token found. Please authenticate with Figma.' }],
+          };
+        }
+
+        const figmaClient = createFigmaClient(figmaToken);
+
+        // Fetch data using shared pipeline
+        const fileDataResults = await fetchBatchData(requests, figmaClient);
+
+        if (fileDataResults.length === 0) {
+          return {
+            content: [{ type: 'text' as const, text: 'Error: No valid Figma URLs provided.' }],
+          };
+        }
+
+        // Write to batch cache
+        console.log('  Writing to batch cache...');
+        const { batchToken, manifest } = await createBatchCache(fileDataResults);
+        console.log(`  ✅ Cached: ${manifest.totalFrames} frames, batchToken: ${batchToken}`);
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              batchToken,
+              manifest: {
+                files: manifest.files,
+                totalFrames: manifest.totalFrames,
+              },
+            }, null, 2),
+          }],
+        };
+      } catch (error: any) {
+        if (error.constructor.name === 'InvalidTokenError') {
+          throw error;
+        }
+        console.log('  ❌ Error in figma-batch-cache:', error.message);
+        return {
+          content: [{ type: 'text' as const, text: `Error in figma-batch-cache: ${error.message}` }],
+        };
+      }
+    }
+  );
+}

--- a/server/providers/figma/tools/figma-batch-cache/index.ts
+++ b/server/providers/figma/tools/figma-batch-cache/index.ts
@@ -1,0 +1,1 @@
+export { registerFigmaBatchCacheTool } from './figma-batch-cache.js';

--- a/server/providers/figma/tools/figma-batch-fetch.ts
+++ b/server/providers/figma/tools/figma-batch-fetch.ts
@@ -1,0 +1,195 @@
+/**
+ * Shared Figma Batch Data Pipeline
+ *
+ * Fetches Figma data for multiple URLs grouped by file.
+ * Used by both figma-batch-zip (builds downloadable zip) and
+ * figma-batch-cache (writes to server-side cache).
+ *
+ * Handles URL grouping, deduplication, and per-file parallel fetching.
+ * Callers decide what to do with the structured data (zip or cache).
+ *
+ * API budget per file: 1 Tier 3 (meta) + 1 Tier 1 (nodes) + 1 Tier 1 (images)
+ */
+
+import type { FigmaClient } from '../figma-api-client.js';
+import { fetchFrameData, type FetchFrameDataResult } from '../screen-analyses-workflow/frame-data-fetcher.js';
+import { generateSemanticXml } from '../semantic-xml-generator.js';
+import { fetchFigmaFileMetadata, toKebabCase } from '../figma-helpers.js';
+import { buildFigmaUrl } from '../screen-analyses-workflow/url-processor.js';
+import { buildFrameContextMarkdown, findConnections } from './figma-ask-scope-questions-for-page/frame-context-builder.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface FetchedFrameData {
+  nodeId: string;
+  name: string;
+  dirName: string;
+  imageBase64: string;
+  structureXml: string;
+  contextMd: string;
+  url: string;
+  order: number;
+  section?: string;
+  annotationCount: number;
+  width?: number;
+  height?: number;
+}
+
+export interface FetchedFileData {
+  fileKey: string;
+  fileName: string;
+  frames: FetchedFrameData[];
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Convert a node ID to a safe directory name: "123:456" → "123-456"
+ */
+export function safeNodeId(nodeId: string): string {
+  return nodeId.replace(/:/g, '-');
+}
+
+/**
+ * Build directory name for a frame: "{safeNodeId}-{kebab-name}"
+ */
+export function frameDirName(nodeId: string, name: string): string {
+  const slug = toKebabCase(name) || 'unnamed';
+  return `${safeNodeId(nodeId)}-${slug}`;
+}
+
+/**
+ * Group URLs by Figma file key, deduplicating within each file.
+ * Returns a Map of fileKey → unique URLs.
+ */
+export function groupUrlsByFileKey(
+  requests: Array<{ url: string; label?: string }>
+): Map<string, string[]> {
+  const urlsByFile = new Map<string, string[]>();
+
+  for (const req of requests) {
+    const match = req.url.match(/\/(file|design)\/([a-zA-Z0-9]+)/);
+    if (!match) {
+      console.log(`  ⚠️ Skipping invalid URL: ${req.url}`);
+      continue;
+    }
+    const fileKey = match[2];
+    const existing = urlsByFile.get(fileKey) || [];
+    existing.push(req.url);
+    urlsByFile.set(fileKey, existing);
+  }
+
+  return urlsByFile;
+}
+
+// ============================================================================
+// Main Pipeline
+// ============================================================================
+
+/**
+ * Fetch and package data for a single Figma file.
+ * Returns structured frame data with images, XML, and context.
+ */
+export async function fetchFileData(
+  urls: string[],
+  figmaClient: FigmaClient,
+  fileKey: string,
+): Promise<FetchedFileData> {
+  console.log(`  Fetching data for file ${fileKey} (${urls.length} URLs)...`);
+
+  // Fetch all frame data using the shared pipeline
+  const result: FetchFrameDataResult = await fetchFrameData(urls, figmaClient, {
+    imageOptions: { format: 'png', scale: 2 },
+  });
+
+  // Get file name
+  const metadata = await fetchFigmaFileMetadata(figmaClient, fileKey);
+
+  // Build reference list for prototype connection resolution
+  const allFrameRefs = result.frames.map(f => ({ id: f.nodeId, name: f.frameName || f.name }));
+
+  // Build per-frame data
+  const frames: FetchedFrameData[] = [];
+  for (const frame of result.frames) {
+    const image = result.images.get(frame.nodeId);
+    if (!image?.base64Data) {
+      console.log(`    ⚠️ Skipping frame ${frame.name} (${frame.nodeId}) — no image`);
+      continue;
+    }
+
+    // Generate semantic XML from node data
+    const nodeData = result.nodesDataMap.get(frame.nodeId);
+    const structureXml = nodeData ? generateSemanticXml(nodeData) : `<!-- No node data for ${frame.name} -->`;
+
+    // Build context markdown (comments, notes, section info, prototype connections)
+    const connections = nodeData ? findConnections(nodeData, allFrameRefs) : [];
+    const contextMd = buildFrameContextMarkdown(
+      {
+        id: frame.nodeId,
+        name: frame.frameName || frame.name,
+        sectionName: frame.sectionName,
+        url: frame.url,
+      },
+      frame.annotations,
+      connections
+    );
+
+    const dirName = frameDirName(frame.nodeId, frame.name);
+    const url = buildFigmaUrl(fileKey, frame.nodeId);
+
+    frames.push({
+      nodeId: frame.nodeId,
+      name: frame.name,
+      dirName,
+      imageBase64: image.base64Data,
+      structureXml,
+      contextMd,
+      url,
+      order: frame.order ?? 0,
+      section: frame.sectionName,
+      annotationCount: frame.annotations.length,
+      width: frame.position?.width,
+      height: frame.position?.height,
+    });
+  }
+
+  console.log(`    ✅ ${frames.length} frames packaged for ${metadata.name}`);
+
+  return {
+    fileKey,
+    fileName: metadata.name,
+    frames,
+  };
+}
+
+/**
+ * Batch-fetch Figma data for multiple URLs, grouped by file.
+ * Handles URL grouping/deduplication and parallel fetching across files.
+ *
+ * @param requests - Array of Figma URLs with optional labels
+ * @param figmaClient - Authenticated Figma API client
+ * @returns Array of per-file structured data
+ */
+export async function fetchBatchData(
+  requests: Array<{ url: string; label?: string }>,
+  figmaClient: FigmaClient,
+): Promise<FetchedFileData[]> {
+  const urlsByFile = groupUrlsByFileKey(requests);
+
+  if (urlsByFile.size === 0) {
+    return [];
+  }
+
+  console.log(`  ${urlsByFile.size} unique files to fetch`);
+
+  // Fetch data per file (parallel across files)
+  const fileDataPromises = Array.from(urlsByFile.entries()).map(
+    ([fileKey, urls]) => fetchFileData(urls, figmaClient, fileKey)
+  );
+
+  return Promise.all(fileDataPromises);
+}

--- a/server/providers/figma/tools/figma-batch-load/figma-batch-load.ts
+++ b/server/providers/figma/tools/figma-batch-load/figma-batch-load.ts
@@ -1,133 +1,40 @@
 /**
- * Figma Batch Load Tool
+ * Figma Batch Load Tool (figma-batch-zip)
  * 
  * Batch-fetches Figma data for multiple URLs (pages or frames, across files),
  * builds a zip containing frame images, structure, context, and prompts,
  * and returns a one-time download URL.
  * 
  * The agent uses `curl` + `unzip` to save everything to `.temp/cascade/figma/`.
+ * For environments where curl is blocked (e.g., GitHub cloud Copilot),
+ * use `figma-batch-cache` instead — it caches data server-side and
+ * subagents retrieve individual frames via `figma-frame-data`.
  * 
  * API budget per file: 1 Tier 3 (meta) + 1 Tier 1 (nodes) + 1 Tier 1 (images)
- * Each frame directory includes context.md with associated comments, notes, and connections.
  */
 
 import { z } from 'zod';
 import { getAuthInfoSafe } from '../../../../mcp-core/auth-helpers.js';
 import type { McpServer } from '../../../../mcp-core/mcp-types.js';
-import { createFigmaClient, type FigmaClient } from '../../figma-api-client.js';
-import { fetchFrameData, type FetchFrameDataResult } from '../../screen-analyses-workflow/frame-data-fetcher.js';
-import { generateSemanticXml } from '../../semantic-xml-generator.js';
-import { fetchFigmaFileMetadata } from '../../figma-helpers.js';
-import { toKebabCase } from '../../figma-helpers.js';
-import { buildFigmaUrl } from '../../screen-analyses-workflow/url-processor.js';
-import { buildFrameContextMarkdown, findConnections } from '../figma-ask-scope-questions-for-page/frame-context-builder.js';
-import { buildZip, type ZipFileData, type ZipFrameData } from './zip-builder.js';
+import { createFigmaClient } from '../../figma-api-client.js';
+import { fetchBatchData } from '../figma-batch-fetch.js';
+import { buildZip } from './zip-builder.js';
 import { registerDownload } from '../../../../api/download.js';
 
-interface FigmaBatchLoadParams {
+interface FigmaBatchZipParams {
   requests: Array<{ url: string; label?: string }>;
   context?: string;
 }
 
 /**
- * Convert a node ID to a safe directory name: "123:456" → "123-456"
+ * Register the figma-batch-zip tool with the MCP server
  */
-function safeNodeId(nodeId: string): string {
-  return nodeId.replace(/:/g, '-');
-}
-
-/**
- * Build directory name for a frame: "{safeNodeId}-{kebab-name}"
- */
-function frameDirName(nodeId: string, name: string): string {
-  const slug = toKebabCase(name) || 'unnamed';
-  return `${safeNodeId(nodeId)}-${slug}`;
-}
-
-/**
- * Fetch and package data for a single Figma file
- */
-async function fetchFileData(
-  urls: string[],
-  figmaClient: FigmaClient,
-  fileKey: string,
-): Promise<ZipFileData> {
-  console.log(`  Fetching data for file ${fileKey} (${urls.length} URLs)...`);
-
-  // Fetch all frame data using the shared pipeline
-  const result: FetchFrameDataResult = await fetchFrameData(urls, figmaClient, {
-    imageOptions: { format: 'png', scale: 2 },
-  });
-
-  // Get file name
-  const metadata = await fetchFigmaFileMetadata(figmaClient, fileKey);
-
-  // Build reference list for prototype connection resolution
-  const allFrameRefs = result.frames.map(f => ({ id: f.nodeId, name: f.frameName || f.name }));
-
-  // Build per-frame zip data
-  const frames: ZipFrameData[] = [];
-  for (const frame of result.frames) {
-    const image = result.images.get(frame.nodeId);
-    if (!image?.base64Data) {
-      console.log(`    ⚠️ Skipping frame ${frame.name} (${frame.nodeId}) — no image`);
-      continue;
-    }
-
-    // Generate semantic XML from node data
-    const nodeData = result.nodesDataMap.get(frame.nodeId);
-    const structureXml = nodeData ? generateSemanticXml(nodeData) : `<!-- No node data for ${frame.name} -->`;
-
-    // Build context markdown (comments, notes, section info, prototype connections)
-    const connections = nodeData ? findConnections(nodeData, allFrameRefs) : [];
-    const contextMd = buildFrameContextMarkdown(
-      {
-        id: frame.nodeId,
-        name: frame.frameName || frame.name,
-        sectionName: frame.sectionName,
-        url: frame.url,
-      },
-      frame.annotations,
-      connections
-    );
-
-    const dirName = frameDirName(frame.nodeId, frame.name);
-    const url = buildFigmaUrl(fileKey, frame.nodeId);
-
-    frames.push({
-      nodeId: frame.nodeId,
-      name: frame.name,
-      dirName,
-      imageBase64: image.base64Data,
-      structureXml,
-      contextMd,
-      url,
-      order: frame.order ?? 0,
-      section: frame.sectionName,
-      annotationCount: frame.annotations.length,
-      width: frame.position?.width,
-      height: frame.position?.height,
-    });
-  }
-
-  console.log(`    ✅ ${frames.length} frames packaged for ${metadata.name}`);
-
-  return {
-    fileKey,
-    fileName: metadata.name,
-    frames,
-  };
-}
-
-/**
- * Register the figma-batch-load tool with the MCP server
- */
-export function registerFigmaBatchLoadTool(mcp: McpServer): void {
+export function registerFigmaBatchZipTool(mcp: McpServer): void {
   mcp.registerTool(
-    'figma-batch-load',
+    'figma-batch-zip',
     {
-      title: 'Batch Load Figma Data',
-      description: 'Batch-fetch Figma data for multiple URLs (pages or frames, across files). Returns a one-time download URL for a zip containing per-frame image.png, structure.xml, context.md (comments, notes, prototype connections), and analysis prompts. Use curl + unzip to extract to .temp/cascade/figma/.',
+      title: 'Batch Load Figma Data (Zip)',
+      description: 'Batch-fetch Figma data for multiple URLs (pages or frames, across files). Returns a one-time download URL for a zip containing per-frame image.png, structure.xml, context.md (comments, notes, prototype connections), and analysis prompts. Use curl + unzip to extract to .temp/cascade/figma/. For environments where curl is blocked, use figma-batch-cache instead.',
       inputSchema: {
         requests: z.array(z.object({
           url: z.string().describe('Figma URL — page-level or frame-level'),
@@ -137,12 +44,12 @@ export function registerFigmaBatchLoadTool(mcp: McpServer): void {
           .describe('Feature context for annotation association'),
       },
     },
-    async ({ requests, context }: FigmaBatchLoadParams, mcpContext) => {
-      console.log('figma-batch-load called');
+    async ({ requests, context }: FigmaBatchZipParams, mcpContext) => {
+      console.log('figma-batch-zip called');
       console.log('  Requests:', requests.length);
 
       try {
-        const authInfo = getAuthInfoSafe(mcpContext, 'figma-batch-load');
+        const authInfo = getAuthInfoSafe(mcpContext, 'figma-batch-zip');
         const figmaToken = authInfo?.figma?.access_token;
 
         if (!figmaToken) {
@@ -153,33 +60,14 @@ export function registerFigmaBatchLoadTool(mcp: McpServer): void {
 
         const figmaClient = createFigmaClient(figmaToken);
 
-        // Group URLs by file key
-        const urlsByFile = new Map<string, string[]>();
-        for (const req of requests) {
-          const match = req.url.match(/\/(file|design)\/([a-zA-Z0-9]+)/);
-          if (!match) {
-            console.log(`  ⚠️ Skipping invalid URL: ${req.url}`);
-            continue;
-          }
-          const fileKey = match[2];
-          const existing = urlsByFile.get(fileKey) || [];
-          existing.push(req.url);
-          urlsByFile.set(fileKey, existing);
-        }
+        // Fetch data using shared pipeline (handles URL grouping + dedup)
+        const fileDataResults = await fetchBatchData(requests, figmaClient);
 
-        if (urlsByFile.size === 0) {
+        if (fileDataResults.length === 0) {
           return {
             content: [{ type: 'text' as const, text: 'Error: No valid Figma URLs provided.' }],
           };
         }
-
-        console.log(`  ${urlsByFile.size} unique files to fetch`);
-
-        // Fetch data per file (parallel across files)
-        const fileDataPromises = Array.from(urlsByFile.entries()).map(
-          ([fileKey, urls]) => fetchFileData(urls, figmaClient, fileKey)
-        );
-        const fileDataResults = await Promise.all(fileDataPromises);
 
         // Build zip
         console.log('  Building zip...');
@@ -210,9 +98,9 @@ export function registerFigmaBatchLoadTool(mcp: McpServer): void {
         if (error.constructor.name === 'InvalidTokenError') {
           throw error;
         }
-        console.log('  ❌ Error in figma-batch-load:', error.message);
+        console.log('  ❌ Error in figma-batch-zip:', error.message);
         return {
-          content: [{ type: 'text' as const, text: `Error in figma-batch-load: ${error.message}` }],
+          content: [{ type: 'text' as const, text: `Error in figma-batch-zip: ${error.message}` }],
         };
       }
     }

--- a/server/providers/figma/tools/figma-batch-load/index.ts
+++ b/server/providers/figma/tools/figma-batch-load/index.ts
@@ -1,1 +1,1 @@
-export { registerFigmaBatchLoadTool } from './figma-batch-load.js';
+export { registerFigmaBatchZipTool } from './figma-batch-load.js';

--- a/server/providers/figma/tools/figma-frame-data/figma-frame-data.ts
+++ b/server/providers/figma/tools/figma-frame-data/figma-frame-data.ts
@@ -1,39 +1,37 @@
 /**
- * MCP Tool: figma-frame-analysis
+ * MCP Tool: figma-frame-data
  *
- * Analyzes a single Figma frame. Returns one frame's image, context, structure,
- * and analysis prompt — everything a subagent needs to analyze one frame.
+ * Returns one frame's image, context markdown, semantic XML, and metadata.
+ * Data only — no prompt text, no save instructions.
  *
  * Two modes:
- * - **Standalone**: Pass a Figma URL. The tool fetches from Figma, caches, and returns.
- * - **Orchestrated**: Pass URL + cacheToken. Reads from server cache (0 API calls).
+ * - **Cached**: Pass URL + batchToken from figma-batch-cache. Reads from server cache (0 API calls).
+ * - **Standalone**: Pass URL only. Fetches from Figma API directly (costs API calls).
  *
- * If the cache is expired, silently falls back to a live Figma fetch via the URL.
+ * Falls back to live fetch if cache is expired.
  */
 
 import { z } from 'zod';
 import type { McpServer } from '../../../../mcp-core/mcp-types.js';
 import { getAuthInfoSafe } from '../../../../mcp-core/auth-helpers.js';
-import { createFigmaClient, type FigmaClient } from '../../figma-api-client.js';
-import { parseFigmaUrl, convertNodeIdToApiFormat, fetchFigmaNodesBatch, downloadFigmaImagesBatch } from '../../figma-helpers.js';
-import { generateSemanticXml } from '../../semantic-xml-generator.js';
+import { createFigmaClient } from '../../figma-api-client.js';
 import {
-  getScopeCacheEntry,
-  readCachedFrameData,
-  type ScopeCacheFrameData,
-} from '../../scope-cache.js';
-import { buildFrameContextMarkdown, findConnections } from '../figma-ask-scope-questions-for-page/frame-context-builder.js';
-import { FRAME_ANALYSIS_PROMPT_TEXT } from '../figma-ask-scope-questions-for-page/prompt-constants.js';
-import { fetchAndAssociateAnnotations } from '../../screen-analyses-workflow/annotation-associator.js';
+  parseFigmaUrl,
+  convertNodeIdToApiFormat,
+  fetchFigmaNodesBatch,
+  downloadFigmaImagesBatch,
+} from '../../figma-helpers.js';
+import { generateSemanticXml } from '../../semantic-xml-generator.js';
+import { getBatchCacheEntry, readBatchFrameData, type BatchCacheFrameData } from '../../batch-cache.js';
 import type { ContentBlock, ImageContent, TextContent, EmbeddedResource } from '../../../../utils/embedded-prompt-builder.js';
 
 // ============================================================================
 // Types
 // ============================================================================
 
-interface FrameAnalysisParams {
+interface FrameDataParams {
   url: string;
-  cacheToken?: string;
+  batchToken?: string;
   includeStructure?: boolean;
   maxStructureSize?: number;
 }
@@ -42,25 +40,23 @@ interface FrameAnalysisParams {
 // Tool Registration
 // ============================================================================
 
-export function registerFigmaFrameAnalysisTool(mcp: McpServer): void {
+export function registerFigmaFrameDataTool(mcp: McpServer): void {
   mcp.registerTool(
-    'figma-frame-analysis',
+    'figma-frame-data',
     {
-      title: '[DEPRECATED] Analyze Single Figma Frame',
+      title: 'Get Figma Frame Data',
       description:
-        '[DEPRECATED — use figma-frame-data instead] ' +
-        'Returns one frame\'s image, context markdown, semantic XML, and analysis prompt. ' +
-        'Use standalone with any Figma frame URL, or pass a cacheToken from ' +
-        'figma-ask-scope-questions-for-page to read from server cache (faster, 0 API calls). ' +
-        'Everything needed to analyze one frame is returned in a single call.',
+        'Returns one frame\'s image, context markdown, semantic XML, and metadata — data only, no prompts or save instructions. ' +
+        'Pass a batchToken from figma-batch-cache to read from server cache (0 API calls). ' +
+        'Without batchToken, fetches directly from Figma API. Falls back to live fetch if cache expired.',
       inputSchema: {
         url: z
           .string()
-          .describe('Figma URL pointing to a specific frame (must contain node-id). The canonical identifier — always works even if cache expired.'),
-        cacheToken: z
+          .describe('Figma URL pointing to a specific frame (must contain node-id).'),
+        batchToken: z
           .string()
           .optional()
-          .describe('Optional cache token from figma-ask-scope-questions-for-page. Reads from server cache instead of hitting Figma API. Falls back to live fetch if expired.'),
+          .describe('Batch token from figma-batch-cache. Reads from server cache (0 API calls). Falls back to live fetch if expired.'),
         includeStructure: z
           .boolean()
           .optional()
@@ -73,11 +69,10 @@ export function registerFigmaFrameAnalysisTool(mcp: McpServer): void {
           .describe('Max characters for semantic XML before truncation (default: 50000).'),
       },
     },
-    async ({ url, cacheToken, includeStructure = true, maxStructureSize = 50000 }: FrameAnalysisParams, mcpContext) => {
-      console.log('figma-frame-analysis called');
-      console.log('  ⚠️ DEPRECATED: Use figma-frame-data instead');
+    async ({ url, batchToken, includeStructure = true, maxStructureSize = 50000 }: FrameDataParams, mcpContext) => {
+      console.log('figma-frame-data called');
       console.log(`  URL: ${url}`);
-      if (cacheToken) console.log(`  cacheToken: ${cacheToken}`);
+      if (batchToken) console.log(`  batchToken: ${batchToken}`);
 
       try {
         // Parse URL to extract fileKey and nodeId
@@ -91,14 +86,14 @@ export function registerFigmaFrameAnalysisTool(mcp: McpServer): void {
         const fileKey = parsed.fileKey;
         const nodeId = convertNodeIdToApiFormat(parsed.nodeId);
 
-        // Try to resolve data from cache first, then fall back to live fetch
+        // Resolve data from cache or live fetch
         const frameData = await resolveFrameData(
-          { fileKey, nodeId, cacheToken, url },
+          { fileKey, nodeId, batchToken, url },
           mcpContext
         );
 
-        // Build response content
-        const content = buildFrameAnalysisResponse(frameData, {
+        // Build response content (data only — no prompts)
+        const content = buildFrameDataResponse(frameData, {
           fileKey,
           url,
           includeStructure,
@@ -107,10 +102,9 @@ export function registerFigmaFrameAnalysisTool(mcp: McpServer): void {
 
         return { content };
       } catch (error: any) {
-        // Re-throw InvalidTokenError for MCP re-auth
         if (error.constructor?.name === 'InvalidTokenError') throw error;
 
-        console.error('figma-frame-analysis error:', error.message);
+        console.error('figma-frame-data error:', error.message);
         return {
           content: [{ type: 'text', text: JSON.stringify({ error: error.message || String(error) }) }],
           isError: true,
@@ -125,22 +119,21 @@ export function registerFigmaFrameAnalysisTool(mcp: McpServer): void {
 // ============================================================================
 
 /**
- * Resolve frame data — try cache first, fall back to live Figma fetch.
- * Cache expiration is invisible to the caller.
+ * Resolve frame data — try batch cache first, fall back to live Figma fetch.
  */
 async function resolveFrameData(
-  params: { fileKey: string; nodeId: string; cacheToken?: string; url: string },
+  params: { fileKey: string; nodeId: string; batchToken?: string; url: string },
   mcpContext: any
-): Promise<ScopeCacheFrameData> {
-  const { fileKey, nodeId, cacheToken } = params;
+): Promise<BatchCacheFrameData> {
+  const { nodeId, batchToken } = params;
 
-  // Attempt 1: Read from scope cache
-  if (cacheToken) {
-    const cacheEntry = await getScopeCacheEntry(cacheToken, fileKey);
+  // Attempt 1: Read from batch cache
+  if (batchToken) {
+    const cacheEntry = await getBatchCacheEntry(batchToken);
     if (cacheEntry) {
-      const cachedFrame = await readCachedFrameData(fileKey, nodeId);
+      const cachedFrame = await readBatchFrameData(batchToken, nodeId);
       if (cachedFrame) {
-        console.log('  ✅ Resolved from scope cache');
+        console.log('  ✅ Resolved from batch cache');
         return cachedFrame;
       }
     }
@@ -157,11 +150,10 @@ async function resolveFrameData(
 async function fetchSingleFrameData(
   params: { fileKey: string; nodeId: string; url: string },
   mcpContext: any
-): Promise<ScopeCacheFrameData> {
+): Promise<BatchCacheFrameData> {
   const { fileKey, nodeId } = params;
 
-  // Get auth
-  const authInfo = getAuthInfoSafe(mcpContext, 'figma-frame-analysis');
+  const authInfo = getAuthInfoSafe(mcpContext, 'figma-frame-data');
   const figmaToken = authInfo?.figma?.access_token;
   if (!figmaToken) {
     throw new Error('No Figma access token found in authentication context.');
@@ -200,8 +192,8 @@ async function fetchSingleFrameData(
     imageMimeType = imageData.mimeType || 'image/png';
   }
 
-  // Build simple context (no annotations from comments API for standalone mode to save API calls)
-  const contextMd = `# ${frameName} (Frame ${nodeId})\n\n_Standalone frame analysis — call figma-ask-scope-questions-for-page for full annotations._\n`;
+  // Build simple context (no full annotations in standalone mode)
+  const contextMd = `# ${frameName} (Frame ${nodeId})\n\n_Standalone frame data — use figma-batch-cache for full annotations and context._\n`;
 
   return {
     nodeId,
@@ -217,8 +209,11 @@ async function fetchSingleFrameData(
 // Response Builder
 // ============================================================================
 
-function buildFrameAnalysisResponse(
-  frameData: ScopeCacheFrameData,
+/**
+ * Build data-only response content blocks — no prompts, no save instructions.
+ */
+function buildFrameDataResponse(
+  frameData: BatchCacheFrameData,
   options: {
     fileKey: string;
     url: string;
@@ -230,29 +225,7 @@ function buildFrameAnalysisResponse(
   const { nodeId, name: frameName, imageBase64, imageMimeType, contextMd, semanticXml } = frameData;
   const content: ContentBlock[] = [];
 
-  // Sanitize frame name for filesystem
-  const safeName = frameName
-    .toLowerCase()
-    .replace(/[^a-z0-9-_]/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '')
-    .substring(0, 80) || 'unnamed';
-
-  const outputDir = `temp/cascade/${fileKey}/frames/${safeName}`;
-
-  // 1. Analysis prompt with save instructions
-  const analysisPrompt = buildAnalysisPromptWithSaveInstructions(
-    undefined, // featureContext is in the cached prompt if available
-    outputDir,
-    frameName
-  );
-
-  content.push({
-    type: 'text',
-    text: analysisPrompt,
-  } as TextContent);
-
-  // 2. Image (one frame = ~500KB, manageable)
+  // 1. Image
   if (imageBase64) {
     content.push({
       type: 'image',
@@ -261,7 +234,7 @@ function buildFrameAnalysisResponse(
     } as ImageContent);
   }
 
-  // 3. Context markdown
+  // 2. Context markdown
   content.push({
     type: 'resource',
     resource: {
@@ -271,7 +244,7 @@ function buildFrameAnalysisResponse(
     },
   } as EmbeddedResource);
 
-  // 4. Semantic XML (with truncation)
+  // 3. Semantic XML (with truncation)
   if (includeStructure && semanticXml) {
     const xml = truncateSemanticXml(semanticXml, maxStructureSize);
     content.push({
@@ -284,45 +257,19 @@ function buildFrameAnalysisResponse(
     } as EmbeddedResource);
   }
 
-  // 5. Metadata
+  // 4. Metadata
   content.push({
     type: 'text',
     text: JSON.stringify({
       frameId: nodeId,
       frameName,
       fileKey,
-      outputPath: `${outputDir}/analysis.md`,
       structureTruncated: semanticXml.length > maxStructureSize,
       structureOriginalSize: semanticXml.length,
     }, null, 2),
   } as TextContent);
 
   return content;
-}
-
-function buildAnalysisPromptWithSaveInstructions(
-  featureContext: string | undefined,
-  outputDir: string,
-  frameName: string
-): string {
-  return `# Frame Analysis Instructions
-
-You are analyzing a single UI frame from a Figma design: **${frameName}**
-
-${FRAME_ANALYSIS_PROMPT_TEXT}
-
-${featureContext ? `## Feature Context\n\n${featureContext}\n\n` : ''}## Save Your Analysis
-
-Write your complete analysis as markdown to:
-
-\`${outputDir}/analysis.md\`
-
-The analysis should follow the format specified above. If the output directory
-doesn't exist, create it first.
-
-This file will be collected by the orchestrating agent for scope synthesis
-across all frames. If you are working standalone (not part of a multi-frame
-workflow), the analysis is still saved for reference and re-use.`;
 }
 
 // ============================================================================
@@ -332,7 +279,6 @@ workflow), the analysis is still saved for reference and re-use.`;
 function truncateSemanticXml(xml: string, maxSize: number): string {
   if (xml.length <= maxSize) return xml;
 
-  // Find a reasonable truncation point — try to cut at a closing tag
   const cutPoint = xml.lastIndexOf('</', maxSize - 200);
   const endTagEnd = cutPoint > 0 ? xml.indexOf('>', cutPoint) + 1 : maxSize;
   const truncated = xml.substring(0, endTagEnd > 0 ? endTagEnd : maxSize);

--- a/server/providers/figma/tools/figma-frame-data/index.ts
+++ b/server/providers/figma/tools/figma-frame-data/index.ts
@@ -1,0 +1,1 @@
+export { registerFigmaFrameDataTool } from './figma-frame-data.js';

--- a/server/providers/figma/tools/index.ts
+++ b/server/providers/figma/tools/index.ts
@@ -6,7 +6,9 @@ import { registerFigmaGetLayersForPageTool } from './figma-get-layers-for-page.j
 import { registerFigmaReviewDesignTool } from './figma-review-design/index.js';
 import { registerFigmaAskScopeQuestionsForPageTool } from './figma-ask-scope-questions-for-page/index.js';
 import { registerFigmaFrameAnalysisTool } from './figma-frame-analysis/index.js';
-import { registerFigmaBatchLoadTool } from './figma-batch-load/index.js';
+import { registerFigmaBatchZipTool } from './figma-batch-load/index.js';
+import { registerFigmaBatchCacheTool } from './figma-batch-cache/index.js';
+import { registerFigmaFrameDataTool } from './figma-frame-data/index.js';
 import { registerFigmaPostCommentTool } from './figma-post-comment.js';
 import { registerFigmaGetCommentsTool } from './figma-get-comments.js';
 
@@ -40,11 +42,17 @@ export function registerFigmaTools(mcp: McpServer, authContext: any): void {
   registerFigmaFrameAnalysisTool(mcp);
   
   // Batch load Figma frames to zip (spec 068 — plugin skills)
-  registerFigmaBatchLoadTool(mcp);
+  registerFigmaBatchZipTool(mcp);
+  
+  // Batch cache Figma frames for MCP retrieval (spec 069 — cloud fallback)
+  registerFigmaBatchCacheTool(mcp);
+  
+  // Per-frame data retrieval, data only (spec 069 — works with batch cache)
+  registerFigmaFrameDataTool(mcp);
   
   // Comment tools (spec 068 — plugin skills)
   registerFigmaPostCommentTool(mcp);
   registerFigmaGetCommentsTool(mcp);
   
-  console.log('  All Figma tools registered (10 tools)');
+  console.log('  All Figma tools registered (12 tools)');
 }

--- a/server/readme.md
+++ b/server/readme.md
@@ -386,14 +386,14 @@ Workflow resources are multi-step orchestration documents that instruct agents h
   - Parameters: `url` (Figma page URL), `context` (optional description)
   - Returns spatial ordering manifest for consistent left-to-right, top-to-bottom processing
 
-- **figma-frame-analysis** 🆕 - Per-frame analysis retrieval tool (spec 067)
+- **figma-frame-analysis** ⚠️ **DEPRECATED** — Use `figma-frame-data` instead
   - Returns one frame's image + context markdown + semantic XML + analysis prompt
   - With `cacheToken`: reads from server-side scope cache (0 Figma API calls)
   - Without `cacheToken`: fetches directly from Figma API (standalone mode, scale:1)
   - Parameters: `url` (Figma frame URL, required), `cacheToken` (optional string)
   - Includes XML truncation for large frames (>50KB) via `truncateSemanticXml()`
 
-- **figma-batch-load** 🆕 - Batch-fetch Figma data for multiple URLs across files
+- **figma-batch-zip** (was `figma-batch-load`) - Batch-fetch Figma data for multiple URLs across files
   - Returns a one-time download URL for a zip containing frame images, semantic XML, and analysis prompts
   - Agent uses `curl` + `unzip` to extract to `.temp/cascade/figma/`
   - Manifest includes per-frame `width` and `height` (from Figma `absoluteBoundingBox`) for comment positioning
@@ -401,6 +401,19 @@ Workflow resources are multi-step orchestration documents that instruct agents h
   - Comments NOT included — use `figma-get-comments` separately
   - Parameters: `requests` (array of `{ url, label? }`), `context` (optional)
   - Returns: `{ downloadUrl, expiresAt, manifest, saveInstructions }`
+
+- **figma-batch-cache** 🆕 - Batch-fetch Figma data into server-side cache (no zip/curl needed)
+  - Ideal for cloud environments where `curl` is blocked
+  - Returns a `batchToken` + `manifest` — frames retrieved individually via `figma-frame-data`
+  - Cache TTL: 10 minutes, extended by 5 minutes on each read
+  - Parameters: `requests` (array of `{ url, label? }`), `context` (optional)
+  - Returns: `{ batchToken, manifest: { files, totalFrames } }`
+
+- **figma-frame-data** 🆕 - Retrieve a single frame's data (image, context, structure)
+  - Two modes: cached (`batchToken` from `figma-batch-cache`) or standalone (live Figma fetch)
+  - Returns raw data only — no prompts or save instructions
+  - Parameters: `url` (Figma frame URL), `batchToken` (optional), `includeStructure` (optional), `maxStructureSize` (optional)
+  - Returns: image + context markdown + semantic XML + metadata content blocks
 
 - **figma-post-comment** 🆕 - Post a comment to a Figma file
   - Optionally pin to a specific node via `nodeId`
@@ -475,7 +488,7 @@ Advanced workflow tools that integrate multiple services:
   - For Jira: includes paginated comments with `hasMoreComments` / `commentsStartAt` support
   - For Confluence: extracts links from page body ADF
   - For Google Docs: extracts URLs via regex from markdown content
-  - For Figma URLs: returns a message to use `figma-batch-load` instead
+  - For Figma URLs: returns a message to use `figma-batch-zip` instead
   - Auto-routes auth: Atlassian token for Jira/Confluence, Google token for Docs/Sheets
   - Parameters: `url` (required), `siteName` (optional), `commentsStartAt` (optional)
   - REST API: `POST /api/extract-linked-resources`
@@ -587,9 +600,22 @@ All REST endpoints accept PAT (Personal Access Token) authentication via headers
 
 ### Figma Endpoints
 
-- **POST /api/figma-batch-load** — Batch-fetch Figma frames → zip download URL
+- **POST /api/figma-batch-zip** — Batch-fetch Figma frames → zip download URL
   - Header: `X-Figma-Token`
   - Body: `{ requests: [{ url, label? }], context? }`
+
+- **POST /api/figma-batch-load** — Legacy alias for `/api/figma-batch-zip` (deprecated)
+  - Same interface as `figma-batch-zip`
+
+- **POST /api/figma-batch-cache** — Batch-fetch Figma frames into server-side cache
+  - Header: `X-Figma-Token`
+  - Body: `{ requests: [{ url, label? }], context? }`
+  - Returns: `{ success, batchToken, manifest }`
+
+- **POST /api/figma-frame-data** — Retrieve one frame's data from cache or live Figma
+  - Header: `X-Figma-Token` (only needed on cache miss)
+  - Body: `{ url, batchToken?, includeStructure?, maxStructureSize? }`
+  - Returns: `{ success, frameData: { frameId, frameName, fileKey, image, context, structure, metadata } }`
 
 - **POST /api/figma-post-comment** — Post a comment to a Figma file
   - Header: `X-Figma-Token`
@@ -621,7 +647,7 @@ All REST endpoints accept PAT (Personal Access Token) authentication via headers
 - **GET /dl/:token** — One-time zip download (no auth header required)
   - Token is the auth mechanism (UUID, single-use, 10-minute TTL)
   - Returns the zip file as `application/zip` with `Content-Disposition: attachment`
-  - Used by agent skills to download `figma-batch-load` results via `curl`
+  - Used by agent skills to download `figma-batch-zip` results via `curl`
 
 ## Plugin Skills
 
@@ -648,10 +674,11 @@ plugins/cascade-mcp/
 
 ### How Skills Interact with MCP Tools
 
-1. Skills call `figma-batch-load` to get a zip download URL
-2. Agent runs `curl` + `unzip` to save data to `.temp/cascade/figma/`
-3. Sub-skills read from the local filesystem (no further MCP calls for cached data)
-4. Results posted via `figma-post-comment`, `atlassian-add-comment`, or `atlassian-update-issue-description`
+1. Skills call `figma-batch-zip` (or `figma-batch-cache` for cloud environments) to get frame data
+2. **Zip path**: Agent runs `curl` + `unzip` to save data to `.temp/cascade/figma/`
+3. **Cache path**: Agent uses `figma-frame-data` with a `batchToken` to retrieve frames via MCP
+4. Sub-skills read from the local filesystem (zip) or MCP (cache) — no further API calls for cached data
+5. Results posted via `figma-post-comment`, `atlassian-add-comment`, or `atlassian-update-issue-description`
 
 ## Key Authentication Patterns
 

--- a/specs/069-figma-batch-cache.md
+++ b/specs/069-figma-batch-cache.md
@@ -1,0 +1,327 @@
+# 069: Figma Batch Cache & Frame Data Tools
+
+**Status:** Draft  
+**Builds on:** [068-plugin-skills.md](./068-plugin-skills.md)
+
+## Problem
+
+The `figma-batch-load` tool (from spec 068) batch-fetches Figma data and returns a one-time zip download URL. The agent uses `curl` + `unzip` to extract the data locally. This works for local agents (VS Code Copilot, Claude Code) but **fails in GitHub's cloud Copilot** — the sandboxed runner cannot resolve external DNS, so `curl` to our server is blocked.
+
+The agent can still make MCP tool calls (GitHub proxies MCP traffic), so we need a cache-based alternative: batch-fetch into server-side cache, then let subagents retrieve individual frames via MCP.
+
+Additionally, the existing `figma-frame-analysis` tool embeds prompt text and save instructions in its response — coupling the tool to a specific workflow. Skills need a data-only tool that returns image, structure, and context without prescribing how to use them.
+
+## Goals
+
+1. New `figma-batch-cache` MCP tool — batch-fetch Figma data into request-token-based server cache, return `batchToken` + manifest
+2. New `figma-frame-data` MCP tool — retrieve one frame's data (image, XML, context) from scope cache, no prompt text
+3. Rename `figma-batch-load` → `figma-batch-zip` for clarity
+4. Share the data-fetching pipeline between `figma-batch-zip` and `figma-batch-cache`
+5. REST API wrappers for both new tools
+6. Deprecate `figma-frame-analysis` and `figma-ask-scope-questions-for-page` (cleanup phase)
+
+## Architecture
+
+### Skill Data Flow — Two Paths
+
+Skills prefer zip (faster, fewer MCP calls), fall back to cache (works everywhere):
+
+```
+Skill SKILL.md
+├── Primary: figma-batch-zip → curl + unzip → .temp/cascade/figma/ → subagents read local files
+│   (Fails in cloud Copilot — DNS blocked)
+│
+└── Fallback: figma-batch-cache → cacheToken + manifest → subagents call figma-frame-data(cacheToken, nodeId)
+    (Works everywhere — all MCP, no curl)
+```
+
+### Detection Logic (in SKILL.md)
+
+```
+1. Call figma-batch-zip(requests)
+2. If response includes downloadUrl:
+   a. Run: curl -sL "{downloadUrl}" -o /tmp/cascade-figma.zip && unzip -qo ... -d .temp/cascade/figma/ && rm /tmp/cascade-figma.zip
+   b. If curl succeeds → use local files for all subsequent work
+   c. If curl fails (exit code != 0) → fall through to step 3
+3. Call figma-batch-cache(requests)
+4. Pass batchToken to subagents — each calls figma-frame-data(url, batchToken)
+```
+
+### Tool Comparison
+
+| | `figma-batch-zip` | `figma-batch-cache` | `figma-frame-data` |
+|-|--------------------|--------------------|--------------------|
+| **Input** | `requests: [{ url, label }]` | `requests: [{ url, label }]` | `url`, `batchToken?` |
+| **What it does** | Batch fetch → build zip → register download | Batch fetch → write to scope cache | Read one frame from scope cache |
+| **Returns** | `{ downloadUrl, manifest }` | `{ batchToken, manifest }` | Image + XML + context (no prompt) |
+| **Data transfer** | HTTP download (zip binary) | MCP response (small JSON) | MCP response (image + text) |
+| **Subagent pattern** | Read local filesystem | Call `figma-frame-data` per frame | N/A (is the subagent tool) |
+| **Works in cloud Copilot** | ❌ (DNS blocked) | ✅ | ✅ |
+
+### Tool Relationship to Existing Tools
+
+| New Tool | Replaces | Key Difference |
+|----------|----------|----------------|
+| `figma-batch-zip` | Was `figma-batch-load` | Renamed for clarity |
+| `figma-batch-cache` | `figma-ask-scope-questions-for-page` (for skills) | No prompts, no orchestration instructions, multi-file support |
+| `figma-frame-data` | `figma-frame-analysis` (for skills) | No prompt text, no save instructions — data only |
+
+## Implementation
+
+### Phase 1: Extract Shared Data Pipeline
+
+The `figma-batch-load` tool's `fetchFileData()` function already does the heavy lifting — fetch nodes, fetch images, generate XML, build context markdown. Extract this into a shared module.
+
+**New file: `server/providers/figma/tools/figma-batch-fetch.ts`**
+
+```typescript
+/**
+ * Shared data-fetching pipeline for figma-batch-zip and figma-batch-cache.
+ * Fetches Figma data for multiple URLs grouped by file, returns structured data.
+ */
+
+export interface FetchedFrameData {
+  nodeId: string;
+  name: string;
+  dirName: string;
+  imageBase64: string;
+  structureXml: string;
+  contextMd: string;
+  url: string;
+  order: number;
+  section?: string;
+  annotationCount: number;
+  width?: number;
+  height?: number;
+}
+
+export interface FetchedFileData {
+  fileKey: string;
+  fileName: string;
+  frames: FetchedFrameData[];
+}
+
+/**
+ * Group URLs by file key, fetch all data for each file in parallel.
+ * Returns structured data — callers decide what to do with it (zip or cache).
+ */
+export async function fetchBatchData(
+  requests: Array<{ url: string; label?: string }>,
+  figmaClient: FigmaClient,
+): Promise<FetchedFileData[]> {
+  // Group URLs by file key
+  // Fetch per file (parallel across files)
+  // Return structured data (same as current fetchFileData logic)
+}
+```
+
+Then:
+- `figma-batch-zip` calls `fetchBatchData()` → `buildZip()` → `registerDownload()`
+- `figma-batch-cache` calls `fetchBatchData()` → `createScopeCache()`
+
+### Phase 2: `figma-batch-cache` Tool
+
+**New file: `server/providers/figma/tools/figma-batch-cache/figma-batch-cache.ts`**
+
+Input schema — same as `figma-batch-zip`:
+```typescript
+{
+  requests: z.array(z.object({
+    url: z.string().describe('Figma URL — page-level or frame-level'),
+    label: z.string().optional().describe('Human label'),
+  })).min(1),
+  context: z.string().optional().describe('Feature context'),
+}
+```
+
+Response — `batchToken` + manifest (no downloadUrl, no saveInstructions):
+```json
+{
+  "batchToken": "a73efd14-dd6f-4a66-9270-e45309998982",
+  "manifest": {
+    "files": [{
+      "fileKey": "abc123",
+      "fileName": "My Design",
+      "frames": [
+        { "nodeId": "1:2", "name": "Login", "dirName": "1-2-login", "url": "...", "order": 0 }
+      ]
+    }],
+    "totalFrames": 5
+  }
+}
+```
+
+Implementation:
+1. Generate `batchToken = crypto.randomUUID()`
+2. Call `fetchBatchData(requests, figmaClient)`
+3. Write all frame data to `cache/figma-batch/{batchToken}/` — manifest.json + per-frame directories
+4. Return `{ batchToken, manifest }`
+
+Cache structure (request-token-based, no file-key indexing):
+```
+cache/figma-batch/{batchToken}/
+├── manifest.json              # Full manifest with all files/frames
+├── .cache-metadata.json       # TTL tracking (createdAt, expiresAt)
+└── frames/
+    ├── {safeNodeId}-{kebab-name}/
+    │   ├── image.png
+    │   ├── structure.xml
+    │   └── context.md
+    └── ...
+```
+
+Does **not** use `scope-cache.ts`. New standalone cache module (`batch-cache.ts`) with:
+- TTL: 10 minutes (extended on read access)
+- Lazy cleanup on creation (same pattern as `scope-cache.ts` and `download.ts`)
+- No cross-request sharing — each batch gets its own isolated directory
+- Security: no data leaks between users/sessions
+
+### Phase 3: `figma-frame-data` Tool
+
+**New file: `server/providers/figma/tools/figma-frame-data/figma-frame-data.ts`**
+
+Input schema:
+```typescript
+{
+  url: z.string().describe('Figma frame URL (must contain node-id)'),
+  batchToken: z.string().optional().describe('Batch token from figma-batch-cache. Reads from server cache (0 API calls). Falls back to live fetch if expired.'),
+  includeStructure: z.boolean().optional().default(true),
+  maxStructureSize: z.number().optional().default(50000),
+}
+```
+
+Response — data only, no prompt, no save instructions:
+```
+Content blocks:
+1. Image (base64 PNG)
+2. Context markdown (embedded resource)
+3. Semantic XML (embedded resource, optional)
+4. Metadata JSON (frameId, frameName, fileKey, structureTruncated)
+```
+
+Compared to `figma-frame-analysis`:
+- ❌ No `FRAME_ANALYSIS_PROMPT_TEXT`
+- ❌ No `buildAnalysisPromptWithSaveInstructions()`
+- ❌ No `outputDir` or file save instructions
+- ✅ Same image, context, XML, metadata
+- ✅ Same `resolveFrameData()` logic (cache first, live fetch fallback)
+- ✅ Same XML truncation
+
+Implementation: Fork `figma-frame-analysis.ts`, strip the prompt/save content blocks from `buildFrameAnalysisResponse()`. Share `resolveFrameData()` and `truncateSemanticXml()` — either by importing from `figma-frame-analysis` or extracting to a shared helper.
+
+Cache lookup: parse `nodeId` from URL → scan `cache/figma-batch/{batchToken}/frames/` for directory matching `{safeNodeId}-*` → read files. No file-key routing needed — node IDs are unique within a batch.
+
+### Phase 4: Rename `figma-batch-load` → `figma-batch-zip`
+
+1. Rename MCP tool registration: `'figma-batch-load'` → `'figma-batch-zip'`
+2. Rename folder: `figma-batch-load/` → `figma-batch-zip/`
+3. Rename REST API: `handleFigmaBatchLoad` → `handleFigmaBatchZip`
+4. Update route in `server/api/index.ts`
+5. Update `server/server.ts` references
+6. Replace `fetchFileData()` with `fetchBatchData()` call from shared module
+7. Update tool description to mention that `figma-batch-cache` is the fallback for environments where `curl` is blocked
+
+### Phase 5: REST API Wrappers
+
+**`server/api/figma-batch-cache.ts`** — same pattern as `figma-batch-load.ts`:
+```typescript
+// Required Headers: X-Figma-Token
+// POST body: { requests: [{ url, label }], context?: string }
+// Returns: { success: true, cacheToken, manifest }
+```
+
+**`server/api/figma-frame-data.ts`** — same pattern as other frame tools:
+```typescript
+// Required Headers: X-Figma-Token (only needed if cacheToken misses)
+// POST body: { url, cacheToken?, includeStructure?, maxStructureSize? }
+// Returns: { success: true, frameData: { image, context, structure, metadata } }
+```
+
+### Phase 6: Skill Updates (spec 068)
+
+Update SKILL.md files to use the two-path pattern:
+
+```markdown
+## Load Figma Data
+
+1. Call `figma-batch-zip` with the Figma URLs from the issue description
+2. If the response includes `downloadUrl`:
+   - Run: `curl -sL "{downloadUrl}" -o /tmp/cascade-figma.zip && unzip -qo /tmp/cascade-figma.zip -d .temp/cascade/figma/ && rm /tmp/cascade-figma.zip`
+   - If the curl command fails (non-zero exit code), proceed to step 3
+   - If it succeeds, all frame data is now in `.temp/cascade/figma/` — use local file reads for all subsequent work
+3. If curl failed or was not attempted:
+   - Call `figma-batch-cache` with the same Figma URLs
+   - Note the `batchToken` from the response
+   - For each frame, call `figma-frame-data(url, batchToken)` to retrieve its data
+```
+
+### Phase 7: Deprecation & Cleanup
+
+Remove after skills are validated:
+
+1. **`figma-ask-scope-questions-for-page`** — replaced by `figma-batch-cache` (data) + skills (orchestration/prompts)
+2. **`figma-frame-analysis`** — replaced by `figma-frame-data` (data only)
+
+Deprecation approach:
+- Add `[DEPRECATED]` prefix to tool descriptions
+- Add console warning when called: `⚠️ figma-frame-analysis is deprecated. Use figma-frame-data instead.`
+- Remove after one release cycle
+
+## Files to Create
+
+| File | Phase | Purpose |
+|------|-------|---------|
+| `server/providers/figma/tools/figma-batch-fetch.ts` | 1 | Shared data-fetching pipeline |
+| `server/providers/figma/batch-cache.ts` | 2 | Request-token-based cache module (create, read, cleanup) |
+| `server/providers/figma/tools/figma-batch-cache/index.ts` | 2 | Export tool registration |
+| `server/providers/figma/tools/figma-batch-cache/figma-batch-cache.ts` | 2 | MCP tool: batch fetch → batch cache |
+| `server/providers/figma/tools/figma-frame-data/index.ts` | 3 | Export tool registration |
+| `server/providers/figma/tools/figma-frame-data/figma-frame-data.ts` | 3 | MCP tool: read one frame, data only |
+| `server/api/figma-batch-cache.ts` | 5 | REST API wrapper |
+| `server/api/figma-frame-data.ts` | 5 | REST API wrapper |
+
+## Files to Modify
+
+| File | Phase | Change |
+|------|-------|--------|
+| `server/providers/figma/tools/figma-batch-load/figma-batch-load.ts` | 1, 4 | Extract `fetchFileData()` to shared module; rename tool to `figma-batch-zip` |
+| `server/providers/figma/tools/figma-batch-load/index.ts` | 4 | Rename export |
+| `server/api/figma-batch-load.ts` | 4 | Rename handler |
+
+| `server/providers/figma/tools/index.ts` | 2, 3 | Register `figma-batch-cache`, `figma-frame-data` |
+| `server/api/index.ts` | 4, 5 | Update route names, add new routes |
+| `server/readme.md` | 7 | Document new tools, deprecations |
+
+## Existing Files Referenced (not modified)
+
+| File | Referenced By | Purpose |
+|------|--------------|---------|
+| `server/providers/figma/screen-analyses-workflow/frame-data-fetcher.ts` | Phase 1 | `fetchFrameData()` — core pipeline reused by shared module |
+| `server/providers/figma/tools/figma-batch-load/zip-builder.ts` | Phase 4 | Unchanged — `figma-batch-zip` continues to use it |
+| `server/api/download.ts` | Phase 4 | Unchanged — `figma-batch-zip` continues to use it |
+| `server/providers/figma/tools/figma-frame-analysis/figma-frame-analysis.ts` | Phase 3 | `resolveFrameData()`, `truncateSemanticXml()` — logic reused in `figma-frame-data` |
+| `server/providers/figma/tools/figma-ask-scope-questions-for-page/frame-context-builder.ts` | Phase 1 | `buildFrameContextMarkdown()`, `findConnections()` — used by shared pipeline |
+
+## Decisions
+
+1. **Request-token-based caching.** `figma-batch-cache` generates a random `batchToken` (`crypto.randomUUID()`) and caches everything under `cache/figma-batch/{batchToken}/`. No file-key indexing, no cross-request sharing. If two users load the same Figma file, they get separate cache entries — safer for security (no data leaking between sessions). `figma-frame-data` only needs `batchToken` + `nodeId` to look up a frame. Does not use `scope-cache.ts` — new standalone cache module with simpler logic.
+
+## Questions
+
+1. Should `figma-frame-data` also support standalone mode (no batchToken, fetches from Figma directly)? `figma-frame-analysis` does this. It's useful but adds complexity and API call cost. If skills always batch-load first, standalone mode may be unnecessary.
+
+Answer: yes it should.  
+
+2. For the shared `fetchBatchData()` module — should it also handle URL grouping/deduplication (currently in `figma-batch-load.ts`), or should callers handle that? Putting it in the shared module means both tools get the same dedup behavior automatically.
+
+yes.
+
+3. How should skills detect that `curl` failed? Options:
+   - (a) Check exit code (exit 6 = DNS resolution failure, exit 7 = connection refused)
+   - (b) Check if the extracted directory exists and contains `manifest.json`
+   - (c) Both — try curl, then verify the output
+
+
+Would skills know their agent?  Ideally the could pick the right option.  But a note about if curl fails to try this different approach would be good.
+
+Btw, the approaches have to differ a bit because I'm not sure agents can "download" images locally.  If NOT using the zip, an agent will need to make the request and look at the data in the mcp response.  It won't be able to look file by file.


### PR DESCRIPTION
- Add figma-batch-cache MCP tool: batch-fetches Figma frames into server-side cache, returns batchToken + manifest
- Add figma-frame-data MCP tool: retrieves single frame data from cache or live Figma (no prompts/save instructions)
- Extract shared fetchBatchData() pipeline into figma-batch-fetch.ts
- Rename figma-batch-load → figma-batch-zip for clarity
- Add REST API endpoints: /api/figma-batch-cache, /api/figma-frame-data, /api/figma-batch-zip
- Add cascade-analyze-figma-frame-mcp skill for cloud environments (MCP path, no filesystem)
- Update write-shell-stories, write-jira-story, write-next-story-from-shell-story, generate-behavior-questions skills with two-path pattern (zip vs cache fallback)
- Add deprecation markers to figma-frame-analysis and figma-ask-scope-questions-for-page
- Update server/readme.md and plugin README with new tools and renamed routes