### PR TITLE
fix: add fonts to Alpine Docker image for SVG text rendering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM node:20-alpine
 ENV PORT=3000
 
+# Install fonts required for SVG-to-PNG text rendering (sharp/librsvg)
+RUN apk add --no-cache fontconfig ttf-dejavu ttf-liberation font-noto-core \
+    && fc-cache -f
+
 WORKDIR /app
 COPY package.json package-lock.json ./
 # npm ci with explicit rollup native binary for Alpine Linux (musl)


### PR DESCRIPTION
- Install fontconfig, ttf-dejavu, ttf-liberation, font-noto-core
- Fixes Miro board region zoom showing □□□ (tofu) characters
- Ensures sharp/librsvg can find font files when rendering SVG to PNG in staging