### PR TITLE
fix: use correct Alpine package name font-noto (not font-noto-core)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20-alpine
 ENV PORT=3000
 
 # Install fonts required for SVG-to-PNG text rendering (sharp/librsvg)
-RUN apk add --no-cache fontconfig ttf-dejavu ttf-liberation font-noto-core \
+RUN apk add --no-cache fontconfig ttf-dejavu ttf-liberation font-noto \
     && fc-cache -f
 
 WORKDIR /app


### PR DESCRIPTION
font-noto-core doesn't exist in Alpine repos, causing Docker build failure.